### PR TITLE
Keep configuration input boxes open when they lose focus

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -27,7 +27,8 @@ export const config = {
 
         var url = await vscode.window.showInputBox(<vscode.InputBoxOptions>{
             prompt: "Enter your Home Assistant (base) URL",
-            placeHolder: "https://your.homeassistant.com:8123"
+            placeHolder: "https://your.homeassistant.com:8123",
+            ignoreFocusOut: true
         });
         if (!url) {
             return false;
@@ -35,7 +36,8 @@ export const config = {
 
         var token = await vscode.window.showInputBox(<vscode.InputBoxOptions>{
             prompt: "Enter a Home Assistant 'Long-Lived Access Token', create one on your user/profile page in HA.",
-            password: true
+            password: true,
+            ignoreFocusOut: true
         });
         if (!token) {
             return false;


### PR DESCRIPTION
Fixes #5

Enabling the [`ignoreFocusOut`](https://code.visualstudio.com/api/references/vscode-api#InputBoxOptions) option ensures that the input box stays open when it loses focus.