### PR TITLE
Fix multi-line entity id completion at first line

### DIFF
--- a/src/entity-id-completion-provider.ts
+++ b/src/entity-id-completion-provider.ts
@@ -37,7 +37,7 @@ export class EntityIdCompletionProvider implements vscode.CompletionItemProvider
 
     isMultiLineMatch(document: vscode.TextDocument, position: vscode.Position): boolean {
         let currentLine = position.line;
-        while (currentLine > 0) {
+        while (currentLine >= 0) {
             var thisLine = document.lineAt(currentLine);
             let isOtherItemInList = thisLine.text.match(/-\s*([-\w]+)?(\.)?([-\w]+?)?\s*$/);
             if (isOtherItemInList) {


### PR DESCRIPTION
`position.line` appears to be zero-based, so the entity id multi-line completions weren't triggering on the first line of the file. This PR should fix the issue 🙂 