### PR TITLE
🚑 Fixes path handling in getUri

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-home-assistant",
-	"version": "0.6.2",
+	"version": "0.6.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-home-assistant",
   "displayName": "Home Assistant Config Helper",
   "description": " Completion for entity-id's in Home Assistant Configurations",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "preview": true,
   "engines": {
     "vscode": "^1.32.0"

--- a/src/server/configuration.ts
+++ b/src/server/configuration.ts
@@ -51,6 +51,6 @@ export class ConfigurationService implements IConfigurationService {
     private getUri =(value: string) : string =>{
         if (!value) return "";
         var uri = Uri.parse(value);
-        return `${uri.scheme}://${uri.authority}.${uri.path.replace(/\/$/, "")}`;
+        return `${uri.scheme}://${uri.authority}${uri.path.replace(/\/$/, "")}`;
     }
 }

--- a/src/server/configuration.ts
+++ b/src/server/configuration.ts
@@ -49,7 +49,9 @@ export class ConfigurationService implements IConfigurationService {
     }
 
     private getUri =(value: string) : string =>{
-        if (!value) return "";
+        if (!value) {
+            return "";
+        }
         var uri = Uri.parse(value);
         return `${uri.scheme}://${uri.authority}${uri.path.replace(/\/$/, "")}`;
     }

--- a/src/server/configuration.ts
+++ b/src/server/configuration.ts
@@ -49,7 +49,8 @@ export class ConfigurationService implements IConfigurationService {
     }
 
     private getUri =(value: string) : string =>{
+        if (!value) return "";
         var uri = Uri.parse(value);
-        return `${uri.scheme}://${uri.authority}`;
+        return `${uri.scheme}://${uri.authority}.${uri.path.replace(/\/$/, "")}`;
     }
 }


### PR DESCRIPTION
`getUri()` should not trigger when the value is empty.
Right now it will always return `://` which makes other checks on `!this.url` not working.

Furthermore, the path is important for some setups, like Hass.io

Hass.io has the API in a path... `http://hassio/homeassistant`, which now breaks since only the authority is used.

Main goals in #7 were SSL handling and the trailing slash. This PR takes those into account as well.

Please note, I've tested this in a transpiled version of the extension, this is dry-coded in here.
**:warning:** Please make sure to test before the merge.