### PR TITLE
Add missing "for" in TemplateTrigger schema

### DIFF
--- a/src/server/schemas/automation.ts
+++ b/src/server/schemas/automation.ts
@@ -28,6 +28,7 @@ export interface TimeTrigger {
 export interface TemplateTrigger {
   platform: "template";
   value_template: string;
+  for?: string | TimePeriod;
 }
 export interface WebhookTrigger {
   platform: "webhook";


### PR DESCRIPTION
The template trigger can use "for" property to delay the event.
https://www.home-assistant.io/docs/automation/trigger/#template-trigger