### PR TITLE
Update ui-lovelace.ts

### DIFF
--- a/src/language-service/src/schemas/ui-lovelace.ts
+++ b/src/language-service/src/schemas/ui-lovelace.ts
@@ -233,6 +233,7 @@ export interface MapCardConfig extends LovelaceCardConfig {
   type: "map"; //Updated
   title?: string;
   aspect_ratio?: string;
+  dark_mode?: boolean;
   default_zoom?: number;
   entities?: Array<EntityConfig | string>;
   geo_location_sources?: string[];


### PR DESCRIPTION
Map card should allow `dark_mode` boolean property. See https://www.home-assistant.io/lovelace/map/#dark_mode for the documentation on this property.

Closes #115