### PR TITLE
Add "description" attribute to Automation.

### DIFF
--- a/src/language-service/src/schemas/automation.ts
+++ b/src/language-service/src/schemas/automation.ts
@@ -4,6 +4,7 @@ export type AutomationsFile = Automation |  Array<Automation>;
 export interface Automation {
   id?: string;
   alias?: string;
+  description?: string;
   initial_state?: string | boolean;
   hide_entity?: boolean;
   trigger: Triggers | Array<Triggers>;


### PR DESCRIPTION
Suppresses error `Property description is not allowed.`