### PR TITLE
Fix some optional properties in ui-lovelace.ts

### DIFF
--- a/src/language-service/src/schemas/ui-lovelace.ts
+++ b/src/language-service/src/schemas/ui-lovelace.ts
@@ -249,8 +249,8 @@ export interface LightCardConfig extends LovelaceCardConfig {
 
 export interface MapCardConfig extends LovelaceCardConfig {
   type: "map";
-  title: string;
-  aspect_ratio: string;
+  title?: string;
+  aspect_ratio?: string;
   default_zoom?: number;
   entities?: Array<EntityConfig | string>;
   geo_location_sources?: string[];
@@ -302,7 +302,7 @@ export interface PictureEntityCardConfig extends LovelaceCardConfig {
   camera_image?: string;
   camera_view?: any;
   state_image?: {};
-  state_filter: string[];
+  state_filter?: string[];
   aspect_ratio?: string;
   tap_action?: ActionConfig;
   hold_action?: ActionConfig;


### PR DESCRIPTION
In the Picture Entity Card, `state_filter` should be optional. Additionally, in the Map Card, `aspect_ratio` and `title` should be optional.