### PR TITLE
MqttSensor: json_attributes_template

### DIFF
--- a/src/language-service/src/schemas/sensors.ts
+++ b/src/language-service/src/schemas/sensors.ts
@@ -27,6 +27,7 @@ export interface MqttSensor {
     payload_available?: string;
     payload_not_available?: string;
     json_attributes_topic?: string;
+    json_attributes_template?: string;
     json_attributes?: string | string[];
     unique_id?: string;
     device_class?: string;


### PR DESCRIPTION
json_attributes is deprecated and replaced by json_attributes_topic

https://www.home-assistant.io/integrations/sensor.mqtt/#json_attributes_template