### PR TITLE
Add optional icon, description and fields to SequencedAction

### DIFF
--- a/src/language-service/src/schemas/homeassistant.ts
+++ b/src/language-service/src/schemas/homeassistant.ts
@@ -168,7 +168,7 @@ export interface InputBooleanEntry {
     [name: string]: {
         name?: string;
         initial?: boolean;
-        icon?: string
+        icon?: string;
     } | null;
 }
 
@@ -180,6 +180,7 @@ export interface Script {
 
 export interface SequencedAction {
     alias?: string;
+    icon?: string;
     sequence: ScriptAction | Array<ScriptAction | ConditionsConfig>;
 }
 

--- a/src/language-service/src/schemas/homeassistant.ts
+++ b/src/language-service/src/schemas/homeassistant.ts
@@ -179,9 +179,18 @@ export interface Script {
 }
 
 export interface SequencedAction {
-    alias?: string;
-    icon?: string;
-    sequence: ScriptAction | Array<ScriptAction | ConditionsConfig>;
+  alias?: string;
+  icon?: string;
+  description?: string;
+  fields?: Array<ScriptField>;
+  sequence: ScriptAction | Array<ScriptAction | ConditionsConfig>;
+}
+
+export interface ScriptField {
+  [name: string]: {
+    description: string;
+    example: string;
+  };
 }
 
 export type ScriptAction = ServiceAction | DelayAction | WaitAction | EventAction;


### PR DESCRIPTION
[Home Assistant Scripts](https://www.home-assistant.io/integrations/script/) support an optional icon variable.

- Adds an optional `icon` property to `SequencedAction`

---

Update (06/05/2020):
- Adds an optional `description` string property
- Adds an optional `fields` array

