### PR TITLE
Removed the string[] as a type for entityid in conditions

### DIFF
--- a/src/language-service/src/schemas/automation.ts
+++ b/src/language-service/src/schemas/automation.ts
@@ -149,7 +149,7 @@ export interface WaitTemplateSchema extends Action{
 
 export interface NumericStateConditionSchema {
   condition: "numeric_state";
-  entity_id: string | string[];
+  entity_id: string;
   below?: string | number;
   above?: string | number;
   value_template?: string;
@@ -157,7 +157,7 @@ export interface NumericStateConditionSchema {
 
 export interface StateConditionSchema {
   condition: "state";
-  entity_id: string | string[];
+  entity_id: string;
   state: string | boolean;
   for?: string | TimePeriod;
   from?: string;


### PR DESCRIPTION
First of all, love your vs extension!

I tried to add a condition to an automation with multiple entityid's (as a list), it parsed in your extension in vs code, but when running the HASS validation tool it failed. As I read in this issue:

https://github.com/home-assistant/core/issues/3620

It seems to be impossible to add multiple entityid's in a condition.