### PR TITLE
Update Lovelace Map Schema hours_to_show

### DIFF
--- a/src/language-service/src/schemas/ui-lovelace.ts
+++ b/src/language-service/src/schemas/ui-lovelace.ts
@@ -277,6 +277,7 @@ export interface MapCardConfig extends LovelaceCardConfig {
   entities?: Array<EntityConfig | string>;
   geo_location_sources?: string[];
   dark_mode?: boolean;
+  hours_to_show?: number;
 }
 
 export interface MarkdownCardConfig extends LovelaceCardConfig {


### PR DESCRIPTION
As of 0.108 the official Lovelace Map card allows you to draw path history using an `hours_to_show` option.

Documentation can be found here: https://www.home-assistant.io/lovelace/map/
Announcement: https://www.home-assistant.io/blog/2020/04/08/release-108/#lovelace-map-history