### PR TITLE
Template rendering MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 </h1>
 
 # Getting started
-      
+
 1. Install via the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=keesschollaart.vscode-home-assistant)
 
 2. Open your (local copy of the) Home Assistant Configuration with VS Code
 
 3. Configure the connection to Home Assistant via the HA Section in the VS Code Settings UI
-   
+
    More details in [the How-To in the Wiki](https://github.com/keesschollaart81/vscode-home-assistant/wiki/Configure-connection-to-HA)
 
 4. Enjoy the features showcased below 👇
@@ -30,29 +30,32 @@
 ## Completion for Entity ID's & Services
 
 When connected with your Home Assistant server, entity id' and services will be auto-completed.
- 
-<img src="https://raw.githubusercontent.com/keesschollaart81/vscode-home-assistant/dev/assets/entity_service_completion.gif"   > 
+
+<img src="https://raw.githubusercontent.com/keesschollaart81/vscode-home-assistant/dev/assets/entity_service_completion.gif"   >
 
 ## Completion & Validation for Configuration & Lovelace Schema
 
 Most of the scheme's of Home Assistant will be validated and things like properties, values and enums will be auto-completed. This extension understands the behaviour of Home Assistant '!include...' behaviour and use this to provide scoped validation for all your files.
- 
-<img src="https://raw.githubusercontent.com/keesschollaart81/vscode-home-assistant/dev/assets/schema_validation_completion.gif"  > 
+
+<img src="https://raw.githubusercontent.com/keesschollaart81/vscode-home-assistant/dev/assets/schema_validation_completion.gif"  >
 
 ## Go to Definition for Includes
 
 Easy navigate between your files references via the different !include... tags using 'f12' / 'Go to Definition'.
- 
-<img src="https://raw.githubusercontent.com/keesschollaart81/vscode-home-assistant/dev/assets/go_to_definition.gif"  > 
+
+<img src="https://raw.githubusercontent.com/keesschollaart81/vscode-home-assistant/dev/assets/go_to_definition.gif"  >
 
 ## Snippets
 
-Snippets allow you to create commonly used data structures very quickly. 
+Snippets allow you to create commonly used data structures very quickly.
 
-<img src="https://raw.githubusercontent.com/keesschollaart81/vscode-home-assistant/dev/assets/snippet.gif"   > 
+<img src="https://raw.githubusercontent.com/keesschollaart81/vscode-home-assistant/dev/assets/snippet.gif"   >
 
 ## Commands
 Commands allow you to quickly interact with Home Assistant! Find them using Cmd+shift+P and type 'Home Assistant'
+
+## Render templates
+Evaluate jinja templates via Home Assistant's API and see how they would render.
 
 ![image](https://user-images.githubusercontent.com/6755359/69496084-6b089d80-0ece-11ea-8496-50251b91732f.png)
 
@@ -63,7 +66,7 @@ Commands allow you to quickly interact with Home Assistant! Find them using Cmd+
 
 # Release Notes
 
-Read all the recent changes in the [GitHub releases section](https://github.com/keesschollaart81/vscode-home-assistant/releases) 
+Read all the recent changes in the [GitHub releases section](https://github.com/keesschollaart81/vscode-home-assistant/releases)
 
 # Feedback / Ideas
 
@@ -72,7 +75,7 @@ Create an [issue](https://github.com/keesschollaart81/vscode-home-assistant/issu
 # Things to do / up for grabs
 
 - [ ] Go to Definition for entities, scripts and automations
-- [ ] Render Jinja2 template locally (like/via CLI?) in preview pane 
+- [ ] Render Jinja2 template locally (like/via CLI?) in preview pane
 - [ ] Autocomplete !secrets
 - [ ] Autocomplete triggers
 - [ ] Check local config with HA Server
@@ -82,9 +85,9 @@ Create an [issue](https://github.com/keesschollaart81/vscode-home-assistant/issu
 |                     | Master   | Dev  |
 |--------------------------------|-----------------|-----------------|
 | Build status |  [![Build Status](https://caseonline.visualstudio.com/vscode-home-assistant/_apis/build/status/keesschollaart81.vscode-home-assistant?branchName=master)](https://caseonline.visualstudio.com/vscode-home-assistant/_build/index?definitionId=23)   | [![Build Status](https://caseonline.visualstudio.com/vscode-home-assistant/_apis/build/status/keesschollaart81.vscode-home-assistant?branchName=dev)](https://caseonline.visualstudio.com/vscode-home-assistant/_build/index?definitionId=23)
-| Deployment Status | [![Deployment Status](https://caseonline.vsrm.visualstudio.com/_apis/public/Release/badge/b5e7419e-352f-433e-8690-463d52b2c4f7/1/2)](https://caseonline.visualstudio.com/vscode-home-assistant/_releases2?definitionId=1) |[![Deployment Status](https://caseonline.vsrm.visualstudio.com/_apis/public/Release/badge/b5e7419e-352f-433e-8690-463d52b2c4f7/1/1)](https://caseonline.visualstudio.com/vscode-home-assistant/_releases2?definitionId=1)|  
-| Get it | [![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/keesschollaart.vscode-home-assistant.svg "Current Release")](https://marketplace.visualstudio.com/items?itemName=keesschollaart.vscode-home-assistant) | [![GitHub release](https://img.shields.io/github/release-pre/keesschollaart81/vscode-home-assistant.svg)](https://github.com/keesschollaart81/vscode-home-assistant/releases)|  
-  
+| Deployment Status | [![Deployment Status](https://caseonline.vsrm.visualstudio.com/_apis/public/Release/badge/b5e7419e-352f-433e-8690-463d52b2c4f7/1/2)](https://caseonline.visualstudio.com/vscode-home-assistant/_releases2?definitionId=1) |[![Deployment Status](https://caseonline.vsrm.visualstudio.com/_apis/public/Release/badge/b5e7419e-352f-433e-8690-463d52b2c4f7/1/1)](https://caseonline.visualstudio.com/vscode-home-assistant/_releases2?definitionId=1)|
+| Get it | [![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/keesschollaart.vscode-home-assistant.svg "Current Release")](https://marketplace.visualstudio.com/items?itemName=keesschollaart.vscode-home-assistant) | [![GitHub release](https://img.shields.io/github/release-pre/keesschollaart81/vscode-home-assistant.svg)](https://github.com/keesschollaart81/vscode-home-assistant/releases)|
+
 # Telemetry
 
 This extension collects telemetry data to help us build a better experience for

--- a/package.json
+++ b/package.json
@@ -168,8 +168,28 @@
         "command": "vscode-home-assistant.getErrorLog",
         "title": "Get Error Logs",
         "category": "Home Assistant"
+      },
+      {
+        "command": "vscode-home-assistant.renderTemplate",
+        "title": "Render Template",
+        "category": "Home Assistant"
       }
     ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "vscode-home-assistant.renderTemplate",
+          "when": "editorHasSelection"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "vscode-home-assistant.renderTemplate",
+          "group": "home-assistant",
+          "when": "editorHasSelection"
+        }
+      ]
+    },
     "configurationDefaults": {
       "[home-assistant]": {
         "editor.insertSpaces": true,

--- a/src/language-service/src/home-assistant/haConnection.ts
+++ b/src/language-service/src/home-assistant/haConnection.ts
@@ -221,13 +221,14 @@ export class HaConnection implements IHaConnection {
         this.connection = undefined;
     }
 
-    public callApi = async (method: string, api: string): Promise<string> => {
+    public callApi = async (method: string, api: string, body?: any): Promise<string> => {
         const options = {
             method: method,
             url: `${this.configurationService.url}/api/${api}`,
             headers: {
                 'Authorization': `Bearer ${this.configurationService.token}`
             },
+            body,
             json: true
         };
 

--- a/src/language-service/src/schemas/generateSchemas.ts
+++ b/src/language-service/src/schemas/generateSchemas.ts
@@ -23,7 +23,7 @@ if (!fs.existsSync(outputFolder)) {
 }
 
 if (fs.readdirSync(outputFolder).length > 0 && process.argv[2] === "--quick") {
-    console.debug("Skipping schema generation becasue there already schema files");
+    console.debug("Skipping schema generation because the schema files are already there");
 }
 else {
     console.log("Generating schema's...");

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -101,9 +101,9 @@ connection.onInitialize(async params => {
 
     if (!configurationService.isConfigured) {
       connection.sendNotification("no-config");
-    } 
+    }
   });
-  
+
   connection.onRequest("callService", (args: { domain: string, service: string, serviceData?: any }) => {
     haConnection.callService(args.domain, args.service, args.serviceData);
   });
@@ -115,9 +115,18 @@ connection.onInitialize(async params => {
     var result = await haConnection.callApi('get', 'error_log');
     connection.sendNotification("get_eror_log_completed", result);
   });
+  connection.onRequest('renderTemplate', async (args: { template: string }) => {
+    var result = await haConnection.callApi('post', 'template', { template: args.template });
+
+    const timePrefix = `[${new Date().toLocaleTimeString()}] `;
+    var outputString = `${timePrefix}Rendering template:\n${args.template}\n\n`
+    outputString += `Result:\n${result}`;
+
+    connection.sendNotification("render_template_completed", outputString);
+  })
 
   //fire and forget
-  setTimeout(discoverFilesAndUpdateSchemas, 0); 
+  setTimeout(discoverFilesAndUpdateSchemas, 0);
 
   return {
     capabilities: <ServerCapabilities>{


### PR DESCRIPTION
👋 Hi,

I saw your idea in the README to _"Render Jinja2 template locally (like/via CLI?) in preview pane"_. I agree it'll be really useful :)

I didn't do exactly that (it's not local), but this PR implements an initial version of Template Rendering.

### Overview

To render templates, I use Home Assistant's `/api/template` endpoint. I reused the existing infrastructure to get request/responses out of the server, and the rest was really easy to do.


The workflow is mostly the same as error logs:
- Registers the `vscode-home-assistant.renderTemplate` command. Adds it for command palette and editor/context menu. The command is available only when there is active text selection.
- `renderTemplate` gets the text selection from the active window and sends a clientRequest to the `LanguageClient`
- on request, `LanguageClient` constructs a request and sends it to HA
- on response and a `render_template_completed` notification, show a new Output CHannel - "Home Assistant Template Renderer"
- the Output Channel is cleared on each new request.

I had to add an optional `body` argument to `HaConnection.callApi`.

### Preview

![2020-05-08 21 51 56](https://user-images.githubusercontent.com/2514425/81439733-7b0ff300-9177-11ea-879a-97b2f2ca1f87.gif)

### To do

There's probably a better way to present the input/output data than what I've done with the Output Channel.

I know you mentioned a preview pane, but I tried working with vscode's WebviewPanel and I don't think it was more convenient.

I think this should be good enough for an initial version and hopefully someone else can take it from here and improve the presentation :)
