### PR TITLE
Add multiple 'to' states

### DIFF
--- a/src/language-service/src/schemas/automation.ts
+++ b/src/language-service/src/schemas/automation.ts
@@ -62,7 +62,7 @@ export interface StateTrigger {
   platform: "state";
   entity_id: string | string[];
   from?: string | boolean;
-  to?: string | boolean;
+  to?: string | string[] | boolean;
   for?: string | TimePeriod;
 }
 export interface TimePeriod {


### PR DESCRIPTION
Example of having multiple states in "to":
```
automation:
  - alias: Turn on busylight if user is in a meeting
    trigger:
      platform: state
      entity_id: sensor.teams_activity # User status in Microsoft Teams 
      to: ["InACall", "InAMeeting"]
    action:
      - service: light.turn_on
        data:
          entity_id: light.bedroom_light
```