### PR TITLE
Schema corrections & additions (as of v1.7.1)

### DIFF
--- a/src/language-service/src/schemas/actions.ts
+++ b/src/language-service/src/schemas/actions.ts
@@ -3,6 +3,8 @@
  * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/config_validation.py
  */
 import {
+  Data,
+  DataTemplate,
   Entity,
   EntityScene,
   IncludeList,
@@ -67,17 +69,13 @@ export interface EventAction {
    * The event data to pass along.
    * https://www.home-assistant.io/docs/scripts/#fire-an-event
    */
-  event_data?: {
-    [key: string]: any;
-  };
+  event_data?: Data;
 
   /**
    * The event data to pass along, using script template.
    * https://www.home-assistant.io/docs/scripts/#fire-an-event
    */
-  event_data_template?: {
-    [key: string]: any | Template;
-  };
+  event_data_template?: DataTemplate;
 }
 
 export interface RepeatAction {
@@ -148,17 +146,13 @@ export interface ServiceAction {
    * Specify other parameters beside the entity to target. For example, the light turn on service allows specifying the brightness.
    * https://www.home-assistant.io/docs/scripts/service-calls/#passing-data-to-the-service-call
    */
-  data?: {
-    [key: string]: any;
-  };
+  data?: Data;
 
   /**
    * Specify other parameters based on templates.
    * https://www.home-assistant.io/docs/scripts/service-calls/#use-templates-to-determine-the-attributes
    */
-  data_template?: {
-    [key: string]: Template;
-  };
+  data_template?: DataTemplate;
 
   /**
    * The entity (or entities) to execute this service call on.

--- a/src/language-service/src/schemas/core.ts
+++ b/src/language-service/src/schemas/core.ts
@@ -38,6 +38,18 @@ export interface Core {
   elevation?: number | Secret;
 
   /**
+   * The URL that Home Assistant is available on from the internet. For example: https://example.duckdns.org:8123. Note that this setting may only contain a protocol, hostname and port; using a path is not supported.
+   * https://www.home-assistant.io/docs/configuration/basic/#external_url
+   */
+  external_url?: string | Secret;
+
+  /**
+   * The URL that Home Assistant is available on from your local network. For example: http://homeassistant.local:8123. Note that this setting may only contain a protocol, hostname and port; using a path is not supported.
+   * https://www.home-assistant.io/docs/configuration/basic/#internal_url
+   */
+  internal_url?: string | Secret;
+
+  /**
    * Latitude of your location required to calculate the time the sun rises and sets.
    * https://www.home-assistant.io/docs/configuration/basic/#latitude
    *

--- a/src/language-service/src/schemas/homeassistant.ts
+++ b/src/language-service/src/schemas/homeassistant.ts
@@ -40,7 +40,7 @@ export interface InternalIntegrations {
    * The input_boolean integration allows the user to define boolean values that can be controlled via the frontend and can be used within conditions of automation. This can for example be used to disable or enable certain automations.
    * https://www.home-assistant.io/integrations/input_boolean
    */
-  input_boolean?: integrations.InputBoolean.Schema | IncludeNamed;
+  input_boolean?: integrations.InputBoolean.Schema | IncludeNamed | null;
 
   /**
    * The panel_iframe support allows you to add additional panels to your Home Assistant frontend. The panels are listed in the sidebar and can contain external resources like the web frontend of your router, your monitoring system, or your media server.

--- a/src/language-service/src/schemas/homeassistant.ts
+++ b/src/language-service/src/schemas/homeassistant.ts
@@ -37,6 +37,12 @@ export interface InternalIntegrations {
   group?: integrations.Group.Schema | IncludeNamed;
 
   /**
+   * The http integration serves all files and data required for the Home Assistant frontend. You only need to add this to your configuration file if you want to change any of the default settings.
+   * https://www.home-assistant.io/integrations/http
+   */
+  http?: integrations.HTTP.Schema | IncludeNamed | null;
+
+  /**
    * The input_boolean integration allows the user to define boolean values that can be controlled via the frontend and can be used within conditions of automation. This can for example be used to disable or enable certain automations.
    * https://www.home-assistant.io/integrations/input_boolean
    */

--- a/src/language-service/src/schemas/integrations/automation.ts
+++ b/src/language-service/src/schemas/integrations/automation.ts
@@ -3,6 +3,7 @@
  * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/__init__.py
  */
 import {
+  Data,
   Deprecated,
   Entity,
   EntityDeviceTracker,
@@ -130,9 +131,7 @@ interface TriggerEvent {
    * Additional event data that has to match before triggering.
    * https://www.home-assistant.io/docs/automation/trigger/#event-trigger
    */
-  event_data?: {
-    [key: string]: any;
-  };
+  event_data?: Data;
 
   /**
    * The name of the event to listen for.

--- a/src/language-service/src/schemas/integrations/http.ts
+++ b/src/language-service/src/schemas/integrations/http.ts
@@ -1,0 +1,95 @@
+/**
+ * HTTP ntegration
+ * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/http/__init__.py
+ */
+import {
+  Deprecated,
+  IncludeList,
+  Port,
+  PositiveInteger,
+  Secret,
+} from "../types";
+
+export type Domain = "http";
+export interface Schema {
+  /**
+   * DEPRECATED.
+   * The base URL has been deprecated, please use internal_url and external_url instead.
+   */
+  base_url?: Deprecated;
+
+  /**
+   * A list of origin domain names to allow CORS requests from. Enabling this will set the Access-Control-Allow-Origin header to the Origin header if it is found in the list, and the Access-Control-Allow-Headers header to Origin, Accept, X-Requested-With, Content-type, Authorization.
+   * https://www.home-assistant.io/integrations/http#cors_allowed_origins
+   */
+  cors_allowed_origins?: string | string[] | Secret | Secret[] | IncludeList;
+
+  /**
+   * Flag indicating whether additional IP filtering is enabled.
+   * https://www.home-assistant.io/integrations/http#ip_ban_enabled
+   */
+  ip_ban_enabled?: boolean;
+
+  /**
+   * Number of failed login attempt from single IP after which it will be automatically banned if ip_ban_enabled is true.
+   * https://www.home-assistant.io/integrations/http#login_attempts_threshold
+   */
+  login_attempts_threshold?: PositiveInteger;
+
+  /**
+   * Only listen to incoming requests on specific IP/host. By default it will accept all IPv4 connections. Use server_host: ::0 if you want to listen to (and only) IPv6.
+   * Warning! Only use this option when you run Home Assistant Core directly in Python!
+   * https://www.home-assistant.io/integrations/http#server_host
+   */
+  server_host?: string | Secret;
+
+  /**
+   * Let you set a port for Home Assistant to run on.
+   * https://www.home-assistant.io/integrations/http#server_port
+   */
+  server_port?: Port;
+
+  /**
+   * Path to your TLS/SSL certificate to serve Home Assistant over a secure connection.
+   * https://www.home-assistant.io/integrations/http#ssl_certificate
+   */
+  ssl_certificate?: string | Secret;
+
+  /**
+   * Path to your TLS/SSL key to serve Home Assistant over a secure connection.
+   * https://www.home-assistant.io/integrations/http#ssl_key
+   */
+  ssl_key?: string | Secret;
+
+  /**
+   * Path to the client/peer TLS/SSL certificate to accept secure connections from.
+   * https://www.home-assistant.io/integrations/http#ssl_peer_certificate
+   */
+  ssl_peer_certificate?: string | Secret;
+
+  /**
+   * The Mozilla SSL profile to use. Only lower if you are experiencing integrations causing SSL handshake errors.
+   * Can be either "modern" or "intermediate". Modern is the default.
+   * https://www.home-assistant.io/integrations/http#ssl_profile
+   */
+  ssl_profile?: "modern" | "intermediate";
+
+  /**
+   * DEPRECATED.
+   * This option has no effect. Please remove this from your configuration.
+   */
+  trusted_networks?: Deprecated;
+
+  /**
+   * List of trusted proxies, consisting of IP addresses or networks, that are allowed to set the X-Forwarded-For header. This is required when using use_x_forwarded_for because all requests to Home Assistant, regardless of source, will arrive from the reverse proxy IP address.
+   * This option should be handled and set with extreme care!
+   * https://www.home-assistant.io/integrations/http#trusted_proxies
+   */
+  trusted_proxies?: string | string[] | Secret | Secret[] | IncludeList;
+
+  /**
+   * Enable parsing of the X-Forwarded-For header, passing on the client’s correct IP address in proxied setups. You must also whitelist trusted proxies using the trusted_proxies setting for this to work. Non-whitelisted requests with this header will be considered IP spoofing attacks, and the header will, therefore, be ignored.
+   * https://www.home-assistant.io/integrations/http#use_x_forwarded_for
+   */
+  use_x_forwarded_for?: boolean;
+}

--- a/src/language-service/src/schemas/integrations/index.d.ts
+++ b/src/language-service/src/schemas/integrations/index.d.ts
@@ -1,6 +1,7 @@
 export * as Automation from "./automation";
 export * as Group from "./group";
 export * as HACS from "./hacs";
+export * as HTTP from "./http";
 export * as Hue from "./hue";
 export * as InputBoolean from "./input_boolean";
 export * as PanelIframe from "./panel_iframe";

--- a/src/language-service/src/schemas/mappings.json
+++ b/src/language-service/src/schemas/mappings.json
@@ -28,6 +28,13 @@
     "fromType": "Schema"
   },
   {
+    "key": "homeassistant-http",
+    "path": "configuration.yaml/http",
+    "file": "homeassistant-http.json",
+    "tsFile": "integrations/http.ts",
+    "fromType": "Schema"
+  },
+  {
     "key": "homeassistant-input-boolean",
     "path": "configuration.yaml/input_boolean",
     "file": "homeassistant-input-boolean.json",

--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -109,6 +109,19 @@ export type IncludeNamed = string;
 export type Integer = number;
 
 /**
+ * @JTS-type integer
+ * @minimum 0
+ */
+export type PositiveInteger = number;
+
+/**
+ * @JTS-type integer
+ * @minimum 1
+ * @maximum 65535
+ */
+export type Port = number;
+
+/**
  * @TJS-pattern ^!secret\s([a-zA-Z0-9_-]+)$
  */
 export type Secret = string;

--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -1,3 +1,11 @@
+export type Data = {
+  [key: string]: any;
+};
+
+export type DataTemplate = {
+  [key: string]: any | Template;
+};
+
 /**
  * @TJS-pattern DEPRECATED^
  */


### PR DESCRIPTION
PR to track schema corrections and additions from v1.7.1.

- Fix `ServiceAction` scheme to allow for non-template type variables in the `data_template` object.
- Created `Data` & `DataTemplate` types for reuse to prevent the above issue from happening again.
- Re-added `internal_url` & `external_url` to core configuration, that somehow went missing in #374
- Fix Input Boolean schema, as the integration accepts null
- Adds HTTP integration schema

