### PR TITLE
Downgrade vscode engine to 1.45.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-home-assistant",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -232,9 +232,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
-      "integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.45.1.tgz",
+      "integrity": "sha512-0NO9qrrEJBO8FsqHCrFMgR2suKnwCsKBWvRSb2OzH5gs4i3QO5AhEMQYrSzDbU/wLPt7N617/rN9lPY213gmwg==",
       "dev": true
     },
     "@types/ws": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.7.2",
   "preview": false,
   "engines": {
-    "vscode": "^1.47.0"
+    "vscode": "^1.45.1"
   },
   "categories": [
     "Other",
@@ -218,7 +218,7 @@
     "@types/mocha": "8.0.0",
     "@types/node": "14.0.22",
     "@types/request": "2.48.5",
-    "@types/vscode": "^1.47.0",
+    "@types/vscode": "1.45.1",
     "@types/ws": "7.2.6",
     "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^3.6.0",

--- a/src/language-service/package-lock.json
+++ b/src/language-service/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "home-assistant-language-service",
-  "version": "1.6.0",
+  "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -197,9 +197,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
-      "integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.45.1.tgz",
+      "integrity": "sha512-0NO9qrrEJBO8FsqHCrFMgR2suKnwCsKBWvRSb2OzH5gs4i3QO5AhEMQYrSzDbU/wLPt7N617/rN9lPY213gmwg==",
       "dev": true
     },
     "@types/ws": {

--- a/src/language-service/package.json
+++ b/src/language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "home-assistant-language-service",
-  "version": "1.7.0",
+  "version": "1.7.2",
   "description": "Home Assistant Language Service",
   "source": "src/haLanguageService.ts",
   "main": "dist/haLanguageService.js",
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@types/mocha": "8.0.0",
     "@types/node": "14.0.22",
-    "@types/vscode": "^1.47.0",
+    "@types/vscode": "1.45.1",
     "@types/ws": "7.2.6",
     "@types/yaml": "1.9.7",
     "@typescript-eslint/eslint-plugin": "^3.6.0",


### PR DESCRIPTION
Downgrades the vscode engine requirements to 1.45.1.
This is the maximum version to gain compatibility with both VSCode & code-server right now.
