### PR TITLE
Improve deprecation schema type

### DIFF
--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -8,8 +8,9 @@ export type DataTemplate = {
 
 /**
  * @TJS-pattern DEPRECATED^
+ * @items.pattern DEPRECATED^
  */
-export type Deprecated = any;
+export type Deprecated = any | any[];
 
 export type DeviceClasses =
   | DeviceClassesBinarySensor


### PR DESCRIPTION
This improves the `Deprecation` schema type, but adding the same (unmatchable) pattern to sub-items in a list/object.

```
deprecated_item:
  - item1
  - item2
```

Would now also match, which previously didn't cause any warning (as the pattern wasn't applied to items in a list).