### PR TITLE
Fix mode typo in automation schema

### DIFF
--- a/src/language-service/src/schemas/integrations/automation.ts
+++ b/src/language-service/src/schemas/integrations/automation.ts
@@ -20,7 +20,7 @@ import { Condition } from "../conditions";
 export type Domain = "automation";
 export type Schema = Item[] | IncludeList;
 
-type Mode = "single" | "parallel" | "queue" | "restart";
+type Mode = "single" | "parallel" | "queued" | "restart";
 
 interface Item {
   /**


### PR DESCRIPTION
Fixes a schema typo in the `mode` parameter of an automation.

`queue` is not a valid mode, it should have been `queued`.

For the action in the script integration it was already correct.