### PR TITLE
Let Dependabot upgrade GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,16 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10
-  target-branch: dev
-  assignees:
-  - keesschollaart81
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 10
+    target-branch: dev
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "06:00"
+    open-pull-requests-limit: 10
+    target-branch: dev


### PR DESCRIPTION
Since this repository migrated to the new dependsbot from GitHub, it is now able to update GitHub Actions workflows as well.

This PR adds the configuration to instruct dependable to just go and update those as well.