### PR TITLE
Add attributes to secondary_info for Lovelace Entities Card

### DIFF
--- a/src/language-service/src/schemas/ui-lovelace.ts
+++ b/src/language-service/src/schemas/ui-lovelace.ts
@@ -156,7 +156,13 @@ export interface EntityFilterEntityConfig extends EntityConfig {
 }
 export interface EntitiesCardEntityConfig extends EntityConfig {
   type?: string;
-  secondary_info?: "entity-id" | "last-changed" | "last-triggered" | "position" | "tilt-position" | "brightness";
+  secondary_info?:
+    | "entity-id"
+    | "last-changed"
+    | "last-triggered"
+    | "position"
+    | "tilt-position"
+    | "brightness";
   format?: "relative" | "total" | "date" | "time" | "datetime";
   action_name?: string;
   service?: string;

--- a/src/language-service/src/schemas/ui-lovelace.ts
+++ b/src/language-service/src/schemas/ui-lovelace.ts
@@ -156,7 +156,7 @@ export interface EntityFilterEntityConfig extends EntityConfig {
 }
 export interface EntitiesCardEntityConfig extends EntityConfig {
   type?: string;
-  secondary_info?: "entity-id" | "last-changed" | "last-triggered";
+  secondary_info?: "entity-id" | "last-changed" | "last-triggered" | "position" | "tilt-position" | "brightness";
   format?: "relative" | "total" | "date" | "time" | "datetime";
   action_name?: string;
   service?: string;


### PR DESCRIPTION
These three attributes is new, `position`, `tilt-position`, `brightness`.

Added here:
https://github.com/home-assistant/frontend/pull/5556
and here
https://github.com/home-assistant/frontend/pull/5731

Note that although all six values are valid, four of them are only valid depending on the entity type.
According to Home Assitant docs:
https://www.home-assistant.io/lovelace/entities/
`entity-id`, `last-changed` (for all)
`last-triggered` (only for automations and scripts)
`position` or `tilt-position` (only for supported covers)
`brightness` (only for lights).

