### PR TITLE
Add Dependabot for the langhuage-service subpackage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
       time: "04:00"
     open-pull-requests-limit: 10
     target-branch: dev
+  - package-ecosystem: npm
+    directory: "/src/language-service"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 10
+    target-branch: dev
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Adjusts dependabot a little, to also pick up dependencies for the language-service subpackage.