### PR TITLE
Fix automation & scene schema not parsed correctly with !include_dir_list

### DIFF
--- a/src/language-service/src/schemas/integrations/automation.ts
+++ b/src/language-service/src/schemas/integrations/automation.ts
@@ -19,6 +19,7 @@ import { Condition } from "../conditions";
 
 export type Domain = "automation";
 export type Schema = Item[] | IncludeList;
+export type File = Item | Item[];
 
 type Mode = "single" | "parallel" | "queued" | "restart";
 

--- a/src/language-service/src/schemas/integrations/scene.ts
+++ b/src/language-service/src/schemas/integrations/scene.ts
@@ -6,6 +6,7 @@ import { IncludeNamed, IncludeList, Deprecated } from "../types";
 
 export type Domain = "scene";
 export type Schema = Item[] | IncludeList;
+export type File = Item | Item[];
 
 interface Item {
   /**

--- a/src/language-service/src/schemas/mappings.json
+++ b/src/language-service/src/schemas/mappings.json
@@ -25,7 +25,7 @@
     "path": "configuration.yaml/scene",
     "file": "homeassistant-scene.json",
     "tsFile": "integrations/scene.ts",
-    "fromType": "Schema"
+    "fromType": "File"
   },
   {
     "key": "homeassistant-http",
@@ -60,7 +60,7 @@
     "path": "configuration.yaml/automation",
     "file": "automations.json",
     "tsFile": "integrations/automation.ts",
-    "fromType": "Schema"
+    "fromType": "File"
   },
   {
     "key": "ui-lovelace",


### PR DESCRIPTION
Fixes (more a workaround) for when the automations or scenes are included by using `include_dir_list`.

Ideally, it should pick the right part of the schema, but that is currently not possible.

fixes #395