### PR TITLE
Cleanup useless template literal

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -216,7 +216,7 @@ export async function activate(
           })
         );
         await vscode.window.showInformationMessage(
-          `Home Assistant inputs reloaded called!`
+          "Home Assistant inputs reload called!"
         );
       }
     )


### PR DESCRIPTION
Removes a useless template literal, fixes a spelling typo in the same go.