### PR TITLE
Add max queue length property to automation

### DIFF
--- a/src/language-service/src/schemas/integrations/automation.ts
+++ b/src/language-service/src/schemas/integrations/automation.ts
@@ -60,8 +60,16 @@ interface Item {
   initial_state?: boolean;
 
   /**
+   * For both queued and parallel modes, configuration option max controls the maximum number of runs that can be executing and/or queued up at a time. The default is 10.
+   * https://www.home-assistant.io/docs/automation/#automation-modes
+   *
+   * @minimum 2
+   */
+  max?: number;
+
+  /**
    * The automation’s mode configuration option controls what happens when the automation is triggered while the actions are still running from a previous trigger.
-   * https://next.home-assistant.io/docs/automation/#automation-modes
+   * https://www.home-assistant.io/docs/automation/#automation-modes
    */
   mode?: Mode;
 


### PR DESCRIPTION
Add the new `max` queue length to the automation item properties.

![image](https://user-images.githubusercontent.com/195327/88588602-1bc7cd80-d058-11ea-9fad-b7f674ebcf57.png)