### PR TITLE
Add the ability to reload HomeKit

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.homekitReload",
+        "title": "Reload HomeKit",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Hassio Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,6 +168,11 @@ export async function activate(
       "reload_themes"
     ),
     new CommandMappings(
+      "vscode-home-assistant.homekitReload",
+      "homekit",
+      "reload"
+    ),
+    new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
       "addon_restart",


### PR DESCRIPTION
Add support for reloading the `homekit` integration (as of Home Assistant 0.115)

See upstream PR:

https://github.com/home-assistant/core/pull/39326


closes #545