### PR TITLE
Add support for multiple times and input_datetime entities in time triggers

### DIFF
--- a/src/language-service/src/schemas/integrations/automation.ts
+++ b/src/language-service/src/schemas/integrations/automation.ts
@@ -8,11 +8,12 @@ import {
   DeviceTrackerEntities,
   Entities,
   IncludeList,
+  InputDatetimeEntities,
   PersonEntities,
   SensorEntities,
   State,
   Template,
-  Time,
+  Times,
   TimePeriod,
   ZoneEntities,
   ZoneEntity,
@@ -358,8 +359,12 @@ interface TriggerTime {
 
   /**
    * Time of day to trigger on, in HH:MM:SS, 24 hours clock format. For example: "13:30:00"
+   * Also accepts input_datetime entities (e.g., input_datetime.start_of_day)
+   *
+   * @TJS-pattern ^(input_datetime\.(?!_)[\da-z_]+(?<!_)\s?(?:,\s?input_datetime\.(?!_)[\da-z_]+(?<!_))*|(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d))$
+   * @items.pattern ^(input_datetime\.(?!_)[\da-z_]+(?<!_)|(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d))$
    */
-  at: Time;
+  at: Times | InputDatetimeEntities;
 }
 
 interface TriggerTimePattern {

--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -88,6 +88,17 @@ export type DeviceTrackerEntity = string;
 export type DeviceTrackerEntities = string | string[];
 
 /**
+ * @TJS-pattern ^input_datetime\.(?!_)[\da-z_]+(?<!_)$
+ */
+export type InputDatetimeEntity = string;
+
+/**
+ * @TJS-pattern ^input_datetime\.(?!_)[\da-z_]+(?<!_)\s?(?:,\s?input_datetime\.(?!_)[\da-z_]+(?<!_))*$
+ * @items.pattern ^input_datetime\.(?!_)[\da-z_]+(?<!_)$
+ */
+export type InputDatetimeEntities = string | string[];
+
+/**
  * @TJS-pattern ^person\.(?!_)[\da-z_]+(?<!_)$
  */
 export type PersonEntity = string;
@@ -183,6 +194,12 @@ export type Template = string;
  * @TJS-pattern ^(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)$
  */
 export type Time = string;
+
+/**
+ * @TJS-pattern ^(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)$
+ * @items.pattern^(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)$
+ */
+export type Times = string | string[];
 
 export type TimePeriod = string | TimePeriodSeconds | TimePeriodMap;
 


### PR DESCRIPTION
Add support for having multiple times set in a single time trigger (introduced in Home Assistant 0.114).

```yaml
- platform: time
  at:
    - "01:00:00"
    - "02:00:00"
```

Add support using `input_datetime` entities in a time trigger (introduced in the upcoming Home Assistant 0.115)

```yaml
- platform: time
  at: input_datetime.start_of_day
```

```yaml
- platform: time
  at:
    - "01:00:00"
    - input_datetime.start_of_day
```

closes #484
closes #535