### PR TITLE
Add support for attributes in state/numeric state trigger

### DIFF
--- a/src/language-service/src/schemas/integrations/automation.ts
+++ b/src/language-service/src/schemas/integrations/automation.ts
@@ -275,6 +275,12 @@ interface TriggerNumericState {
    * https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger
    */
   for?: TimePeriod | Template;
+
+  /**
+   * Use the value of a specific entity attribute to trigger on, instead of the entity state.
+   * https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger
+   */
+  attribute?: string;
 }
 
 interface TriggerState {
@@ -307,6 +313,12 @@ interface TriggerState {
    * https://www.home-assistant.io/docs/automation/trigger/#state-trigger
    */
   to?: State | State[];
+
+  /**
+   * Use the value of a specific entity attribute to trigger on, instead of the entity state.
+   * https://www.home-assistant.io/docs/automation/trigger/#state-trigger
+   */
+  attribute?: string;
 }
 
 interface TriggerSun {


### PR DESCRIPTION
Home Assistant 0.115 will add support for adding (numeric) state triggers based on an entity attribute.

```yaml
trigger:
  - platform: state
    entity_id: climate.living_room
    from: "off"
    to: "heat"
    attribute: havc_mode
```

```yaml
trigger:
  - platform: numeric_state
    entity_id: climate.living_room
    attribute: temperature
    above: 20
```

Upstream PR: <https://github.com/home-assistant/core/pull/39238>

Closes #533