### PR TITLE
Add support for attributes in (numeric) state conditions

### DIFF
--- a/src/language-service/src/schemas/conditions.ts
+++ b/src/language-service/src/schemas/conditions.ts
@@ -107,6 +107,12 @@ export interface NumericStateCondition {
    * https://www.home-assistant.io/docs/scripts/conditions/#numeric-state-condition
    */
   value_template?: Template;
+
+  /**
+   * Use the value of a specific entity attribute to test against, instead of the entity state.
+   * https://www.home-assistant.io/docs/scripts/conditions/#numeric-state-condition
+   */
+  attribute?: string;
 }
 
 export interface OrCondition {
@@ -153,6 +159,12 @@ export interface StateCondition {
    * This option has no effect, please remove it.
    */
   from?: Deprecated;
+
+  /**
+   * Use the value of a specific entity attribute to test against, instead of the entity state.
+   * https://www.home-assistant.io/docs/scripts/conditions/#state-condition
+   */
+  attribute?: string;
 }
 
 export interface SunCondition {


### PR DESCRIPTION
Home Assistant 0.115 adds support for having automation/script conditions on attribute values:

```yaml
- condition: state
  entity_id: light.hue
  attribute: hue_group
  state: "on"
```

```yaml
- condition: numeric_state
  entity_id: sensor.temperature
  attribute: outside
  above: 20
```

Upstream PR: https://github.com/home-assistant/core/pull/39050

closes #532