### PR TITLE
Data template changes in service calls

### DIFF
--- a/src/language-service/src/schemas/actions.ts
+++ b/src/language-service/src/schemas/actions.ts
@@ -4,7 +4,7 @@
  */
 import {
   Data,
-  DataTemplate,
+  Deprecated,
   Entities,
   IncludeList,
   Integer,
@@ -109,10 +109,11 @@ export interface EventAction {
   event_data?: Data;
 
   /**
-   * The event data to pass along, using script template.
+   * DEPRECATED as of Home Assistant 0.115.
+   * You can use templates directly in the event_data parameter, replace "event_data_template" with just "event_data".
    * https://www.home-assistant.io/docs/scripts/#fire-an-event
    */
-  event_data_template?: DataTemplate;
+  event_data_template?: Deprecated;
 }
 
 export interface RepeatAction {
@@ -174,10 +175,11 @@ export interface ServiceAction {
   service?: string;
 
   /**
-   * Allow the service to call to be generated from a template.
+   * DEPRECATED as of Home Assistant 0.115.
+   * You can use templates directly in the service parameter, replace "service_template" with just "service".
    * https://www.home-assistant.io/docs/scripts/service-calls/#use-templates-to-decide-which-service-to-call
    */
-  service_template?: Template;
+  service_template?: Deprecated;
 
   /**
    * Specify other parameters beside the entity to target. For example, the light turn on service allows specifying the brightness.
@@ -186,10 +188,11 @@ export interface ServiceAction {
   data?: Data;
 
   /**
-   * Specify other parameters based on templates.
+   * DEPRECATED as of Home Assistant 0.115.
+   * You can use templates directly in the data parameter, replace "data_template" with just "data".
    * https://www.home-assistant.io/docs/scripts/service-calls/#use-templates-to-determine-the-attributes
    */
-  data_template?: DataTemplate;
+  data_template?: Deprecated;
 
   /**
    * The entity (or entities) to execute this service call on.

--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -1,8 +1,4 @@
 export type Data = {
-  [key: string]: any;
-};
-
-export type DataTemplate = {
   [key: string]: any | Template;
 };
 

--- a/src/snippets/homeassistant_automation.json
+++ b/src/snippets/homeassistant_automation.json
@@ -114,7 +114,7 @@
     "prefix": "action-service",
     "body": [
       "- service: ${1:service name}",
-      "  data_template:",
+      "  data:",
       "    entity_id: ${2:entity_id}"
     ],
     "description": "Add a Home Assistant service action for automation"


### PR DESCRIPTION
Upstream PR:

<https://github.com/home-assistant/core/pull/39210>

`service_template`, `data_template`, and `event_data_template` are now obsolete. Instead, the `server`, `data` and `event_data` now just accept a mixed context of scalar values and templates.

I've added a deprecation warning for the older vars. While not truly deprecated, I think the extension should follow the latest and best practices.

closes #531
