### PR TITLE
Fix number state trigger strictness on entity_id

### DIFF
--- a/src/language-service/src/schemas/integrations/automation.ts
+++ b/src/language-service/src/schemas/integrations/automation.ts
@@ -10,7 +10,6 @@ import {
   IncludeList,
   InputDatetimeEntities,
   PersonEntities,
-  SensorEntities,
   State,
   Template,
   Times,
@@ -251,7 +250,7 @@ interface TriggerNumericState {
    * The entity ID or list of entity IDs to monitor the numeric state for.
    * https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger
    */
-  entity_id: SensorEntities;
+  entity_id: Entities;
 
   /**
    * Fire this trigger if the numeric state of the monitored entity (or entities) is changing from above to below the given threshold.


### PR DESCRIPTION
Fixes an issue with the numeric state trigger to be too strict on the entity it accepts.

With Home Assistant 0.115 this will become worse, as that now supports entity attributes as well.

To fix the issue and mitigate potential issues at 0.115, this PR adjusts the numeric state trigger to support any entity (which is true).

fixes #473