### PR TITLE
Fix Core packages root schema

### DIFF
--- a/src/language-service/src/schemas/core.ts
+++ b/src/language-service/src/schemas/core.ts
@@ -89,7 +89,7 @@ export interface Core {
    * Packages in Home Assistant provide a way to bundle different component’s configuration together. It allows for "splitting" your configuration.
    * https://www.home-assistant.io/docs/configuration/packages/
    */
-  packages?: Array<HomeAssistantRoot> | IncludeNamed;
+  packages?: HomeAssistantRoot | IncludeNamed;
 
   /**
    * Pick your time zone from the column TZ of Wikipedia’s list of tz database time


### PR DESCRIPTION
Fixes the core `packages` config to expect an include(named) or an array of roots. The core does not expect an array of roots, but a root itself (that could be combined using includes).

Ensures this works now:

```yaml
homeassistant:
  packages:
    vacuum: !include vacuum.yaml
    weather: !include weather.yaml
    draytek: !include draytek.yaml
    garbage: !include garbage.yaml
    download: !include download.yaml
    scounters: !include scounters.yaml
```

fixes #456