### PR TITLE
Add support for reloading min_max

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.minMaxReload",
+        "title": "Reload Min/Max",
+        "category": "Home Assistant"
+      },      
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Hassio Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,6 +178,11 @@ export async function activate(
       "reload"
     ),
     new CommandMappings(
+      "vscode-home-assistant.minMaxReload",
+      "min_max",
+      "reload"
+    ),
+    new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
       "addon_restart",


### PR DESCRIPTION
As of Home Assistant 0.115, the `min_max` integration can be reloaded.

See upstream PR:

https://github.com/home-assistant/core/pull/39327

closes #546