### PR TITLE
Remove occurrences of Hass.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,12 +159,12 @@
       },      
       {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
-        "title": "Restart 'Git Pull' Hassio Add-on",
+        "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"
       },
       {
         "command": "vscode-home-assistant.hassioHostReboot",
-        "title": "Reboot Hassio Host",
+        "title": "Reboot Supervisor Host",
         "category": "Home Assistant"
       },
       {


### PR DESCRIPTION
Hass.io doesn't exist as a name anymore and has been replaced by just "Home Assistant".

This PR removes 2 user-facing occurrences of the old "Hass.io" term.