### PR TITLE
Add the ability to reload generic_thermostat integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,11 @@
         "category": "Home Assistant"
       },      
       {
+        "command": "vscode-home-assistant.genericThermostatReload",
+        "title": "Reload Generic Thermostat",
+        "category": "Home Assistant"
+      },      
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Hassio Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -183,6 +183,11 @@ export async function activate(
       "reload"
     ),
     new CommandMappings(
+      "vscode-home-assistant.genericThermostatReload",
+      "generic_thermostat",
+      "reload"
+    ),
+    new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
       "addon_restart",


### PR DESCRIPTION
As of Home Assistant 0.115, the `generic_thermostat` can be reloaded.

See upstream PR:

https://github.com/home-assistant/core/pull/39291

closes #544