### PR TITLE
Add the ability to reload generic camera integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,11 @@
         "category": "Home Assistant"
       },      
       {
+        "command": "vscode-home-assistant.genericCameraReload",
+        "title": "Reload Generic Camera",
+        "category": "Home Assistant"
+      },      
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,6 +188,11 @@ export async function activate(
       "reload"
     ),
     new CommandMappings(
+      "vscode-home-assistant.genericCameraReload",
+      "generic",
+      "reload"
+    ),
+    new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
       "addon_restart",


### PR DESCRIPTION
As of Home Assistant 0.115, the `generic` can be reloaded.

See upstream PR:

https://github.com/home-assistant/core/pull/39289

closes #543