### PR TITLE
Add the ability to reload ping integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,17 +156,22 @@
         "command": "vscode-home-assistant.minMaxReload",
         "title": "Reload Min/Max",
         "category": "Home Assistant"
-      },      
+      },
       {
         "command": "vscode-home-assistant.genericThermostatReload",
         "title": "Reload Generic Thermostat",
         "category": "Home Assistant"
-      },      
+      },
       {
         "command": "vscode-home-assistant.genericCameraReload",
         "title": "Reload Generic Camera",
         "category": "Home Assistant"
-      },      
+      },
+      {
+        "command": "vscode-home-assistant.pingReload",
+        "title": "Reload Ping",
+        "category": "Home Assistant"
+      },
       {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -192,6 +192,7 @@ export async function activate(
       "generic",
       "reload"
     ),
+    new CommandMappings("vscode-home-assistant.pingReload", "ping", "reload"),
     new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",


### PR DESCRIPTION
As of Home Assistant 0.115, the `ping` integration can be reloaded.

See upstream PR:

https://github.com/home-assistant/core/pull/39344


closes #549 