### PR TITLE
Add the ability to reload trend integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,6 +173,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.trendReload",
+        "title": "Reload Trend",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -193,6 +193,7 @@ export async function activate(
       "reload"
     ),
     new CommandMappings("vscode-home-assistant.pingReload", "ping", "reload"),
+    new CommandMappings("vscode-home-assistant.trendReload", "trend", "reload"),
     new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",


### PR DESCRIPTION
As of Home Assistant 0.115, the `trend` integration can be reloaded.

See upstream PR:

https://github.com/home-assistant/core/pull/39341

closes #548