### PR TITLE
Add the ability to reload history_stats integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.historyStatsReload",
+        "title": "Reload History Stats",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -195,6 +195,11 @@ export async function activate(
     new CommandMappings("vscode-home-assistant.pingReload", "ping", "reload"),
     new CommandMappings("vscode-home-assistant.trendReload", "trend", "reload"),
     new CommandMappings(
+      "vscode-home-assistant.historyStatsReload",
+      "history_stats",
+      "reload"
+    ),
+    new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
       "addon_restart",


### PR DESCRIPTION
As of Home Assistant 0.115, the `history_stats ` integration can be reloaded.

See upstream PR:

https://github.com/home-assistant/core/pull/39337

closes #547 