### PR TITLE
Add the ability to reload universal media player

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,6 +183,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.universalReload",
+        "title": "Reload Universal Media Player",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -200,6 +200,11 @@ export async function activate(
       "reload"
     ),
     new CommandMappings(
+      "vscode-home-assistant.universalReload",
+      "universal",
+      "reload"
+    ),
+    new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
       "addon_restart",


### PR DESCRIPTION
As of Home Assistant 0.115, the `universal` media player can be reloaded.

See upstream PR:

https://github.com/home-assistant/frontend/pull/6697

closes #530