### PR TITLE
Add the ability to reload statistics integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.statisticsReload",
+        "title": "Reload Statistics",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,6 +205,11 @@ export async function activate(
       "reload"
     ),
     new CommandMappings(
+      "vscode-home-assistant.statisticsReload",
+      "statistics",
+      "reload"
+    ),
+    new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
       "addon_restart",


### PR DESCRIPTION
As of Home Assistant 0.115, the `statistics` platform can be reloaded.

See upstream PR:

https://github.com/home-assistant/core/pull/39268

closes #528