### PR TITLE
Add the ability to reload filter integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.filterReload",
+        "title": "Reload Filter",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -210,6 +210,11 @@ export async function activate(
       "reload"
     ),
     new CommandMappings(
+      "vscode-home-assistant.filterReload",
+      "filter",
+      "reload"
+    ),
+    new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
       "addon_restart",


### PR DESCRIPTION
As of Home Assistant 0.115, the `filter` platform can be reloaded.

See upstream PR:

<https://github.com/home-assistant/core/pull/39267>

closes #527 