### PR TITLE
Add support for reloading REST integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.restReload",
+        "title": "Reload REST",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -214,6 +214,7 @@ export async function activate(
       "filter",
       "reload"
     ),
+    new CommandMappings("vscode-home-assistant.restReload", "rest", "reload"),
     new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",


### PR DESCRIPTION
As of Home Assistant 0.115, the rest platform can be reloaded.

closes #526