### PR TITLE
Add support for reloading command_line integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,6 +203,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.commandLineReload",
+        "title": "Reload Command Line",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -216,6 +216,11 @@ export async function activate(
     ),
     new CommandMappings("vscode-home-assistant.restReload", "rest", "reload"),
     new CommandMappings(
+      "vscode-home-assistant.commandLineReload",
+      "command_line",
+      "reload"
+    ),
+    new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
       "addon_restart",


### PR DESCRIPTION
As of Home Assistant 0.115, the `command_line` platform can be reloaded.

See upstream PR:

<https://github.com/home-assistant/core/pull/39262>

closes #525