### PR TITLE
Add support for Lovelace URL action

### DIFF
--- a/src/language-service/src/schemas/ui-lovelace.ts
+++ b/src/language-service/src/schemas/ui-lovelace.ts
@@ -127,11 +127,17 @@ export interface NoActionConfig {
   action: "none";
 }
 
+export interface UrlActionConfig {
+  action: "url";
+  url_path: string;
+}
+
 export type ActionConfig =
   | ToggleActionConfig
   | CallServiceActionConfig
   | NavigateActionConfig
   | MoreInfoActionConfig
+  | UrlActionConfig
   | NoActionConfig;
 
 export interface AlarmPanelCardConfig extends LovelaceCardConfig {


### PR DESCRIPTION
Add support for the Lovelace `url` action.

closes #452