### PR TITLE
Fix option state-filter in Lovelace picture elements card

### DIFF
--- a/src/language-service/src/schemas/ui-lovelace.ts
+++ b/src/language-service/src/schemas/ui-lovelace.ts
@@ -332,7 +332,7 @@ export interface PictureElementsCardConfig extends LovelaceCardConfig {
   camera_image?: string;
   camera_view?: any;
   state_image?: any;
-  state_filter: string[];
+  state_filter?: Array<{ key: string } | string>;
   aspect_ratio?: string;
   entity?: string;
   elements: Elements;


### PR DESCRIPTION
Fixes the `state-filter` property on the picture elements card. It had the wrong type and was incorrectly marked as required.

fixes #454