### PR TITLE
Add support for shorthand template conditions

### DIFF
--- a/src/language-service/src/schemas/conditions.ts
+++ b/src/language-service/src/schemas/conditions.ts
@@ -5,6 +5,7 @@
 import {
   Deprecated,
   DeviceTrackerEntities,
+  DynamicTemplate,
   Entities,
   IncludeList,
   State,
@@ -19,6 +20,7 @@ export type Weekday = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
 export type Condition =
   | AndCondition
   | DeviceCondition
+  | DynamicTemplate
   | NotCondition
   | NumericStateCondition
   | OrCondition

--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -187,6 +187,13 @@ export type State = number | string;
 export type Template = string;
 
 /**
+ * Dynamic template must contain Jinja
+ *
+ * @TJS-pattern \{(?:[%\{#])
+ */
+export type DynamicTemplate = string;
+
+/**
  * @TJS-pattern ^(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)$
  */
 export type Time = string;


### PR DESCRIPTION
Add support for the shorthand template conditions introduced in Home Assistant 0.115

Upstream PR: <https://github.com/home-assistant/core/pull/39705>

Basically it allows for:

```yaml
conditions: {{ template }}
```

Or combined in a list of conditions:

```yaml
conditions:
  - {{ template }}
  - condition: state
    ...
```

More examples:

```yaml
automation:
  - alias: test
    trigger:
      ...
    condition: "{{ is_state('input_boolean.go', 'on') }}"
    action:
      ...
```

```yaml
automation:
  - alias: test
    trigger:
      ...
    condition:
      - "{{ is_state('input_boolean.go', 'on') }}"
      - condition: state
        ...
      - "{{ is_state('input_boolean.stop', 'off') }}"
    action:
      ...
```

```yaml
- choose:
    - conditions: "{{ trigger.to_state.state == 'home' }}"
      sequence:
        - ...
    - conditions: 
        - "{{ trigger.to_state.state == 'office' }}"
        - condition: state
          ...
      sequence:
        - ...
```

```yaml
- repeat:
    while: "{{ is_state('input_boolean.go', 'on') }}"
    sequence:
      - ...
- repeat:
    while: 
      - "{{ is_state('input_boolean.go', 'on') }}"
      - condition: state
        ...
    sequence:
      - ...
```

```yaml
- condition: not
  conditions: "{{ is_state('input_boolean.go', 'on') }}"
```

```yaml
- condition: or
  conditions:
    - "{{ is_state('input_boolean.go', 'on') }}"
    - condition: state
      ...
```

closes #595