### PR TITLE
Add support for max_exceeded in automation and script run modes

### DIFF
--- a/src/language-service/src/schemas/integrations/automation.ts
+++ b/src/language-service/src/schemas/integrations/automation.ts
@@ -62,6 +62,21 @@ interface Item {
   mode?: Mode;
 
   /**
+   * When `max` is exceeded (which is effectively 1 for `single` mode) a log message will be emitted to indicate this has happened. This controls the severity level of that log message
+   * https://www.home-assistant.io/docs/automation/#automation-modes
+   */
+  max_exceeded?:
+    | "silent"
+    | "notset"
+    | "debug"
+    | "info"
+    | "warn"
+    | "warning"
+    | "error"
+    | "fatal"
+    | "critical";
+
+  /**
    * Triggers describe events that should trigger the automation rule.
    * https://www.home-assistant.io/docs/automation/#automation-basics
    */

--- a/src/language-service/src/schemas/integrations/script.ts
+++ b/src/language-service/src/schemas/integrations/script.ts
@@ -55,6 +55,21 @@ interface Item {
   mode?: Mode;
 
   /**
+   * When `max` is exceeded (which is effectively 1 for `single` mode) a log message will be emitted to indicate this has happened. This controls the severity level of that log message
+   * https://www.home-assistant.io/integrations/script/#script-modes
+   */
+  max_exceeded?:
+    | "silent"
+    | "notset"
+    | "debug"
+    | "info"
+    | "warn"
+    | "warning"
+    | "error"
+    | "fatal"
+    | "critical";
+
+  /**
    * The sequence of actions to be performed in the script.
    * https://www.home-assistant.io/integrations/script/#sequence
    */


### PR DESCRIPTION
Adds support for `max_exceeded` in automation & script run modes, added in Home Assistant 0.115

Upstream PR: <https://github.com/home-assistant/core/pull/39448>