### PR TITLE
Add support for script and automation variables

### DIFF
--- a/src/language-service/src/schemas/actions.ts
+++ b/src/language-service/src/schemas/actions.ts
@@ -25,6 +25,7 @@ export type Action =
   | ServiceAction
   | WaitForTriggerAction
   | WaitTemplateAction
+  | VariablesAction
   | Condition; // A condition is a valid action
 
 export interface ChooseAction {
@@ -251,4 +252,17 @@ export interface WaitTemplateAction {
    * https://www.home-assistant.io/docs/scripts/#wait
    */
   continue_on_timeout?: boolean;
+}
+
+export interface VariablesAction {
+  /**
+   * Alias for the variables action.
+   */
+  alias?: string;
+
+  /**
+   * The variable command allows you to set/override variables that will be accessible by templates in actions after it.
+   * https://www.home-assistant.io/docs/scripts/#variables
+   */
+  variables: Data;
 }

--- a/src/language-service/src/schemas/integrations/automation.ts
+++ b/src/language-service/src/schemas/integrations/automation.ts
@@ -2,7 +2,7 @@
  * Automation integration
  * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/__init__.py
  */
-import { Deprecated, IncludeList } from "../types";
+import { Data, Deprecated, IncludeList } from "../types";
 import { Action } from "../actions";
 import { Condition } from "../conditions";
 import { Trigger } from "../triggers";
@@ -81,6 +81,12 @@ interface Item {
    * https://www.home-assistant.io/docs/automation/#automation-basics
    */
   trigger: Trigger | Trigger[] | IncludeList;
+
+  /**
+   * Variables that will be available inside your templates and conditions.
+   * https://www.home-assistant.io/docs/automation/#automation-basics
+   */
+  variables?: Data;
 
   /**
    * Conditions are optional tests that can limit an automation rule to only work in your specific use cases. A condition will test against the current state of the system. This includes the current time, devices, people and other things like the sun.

--- a/src/language-service/src/schemas/integrations/script.ts
+++ b/src/language-service/src/schemas/integrations/script.ts
@@ -2,7 +2,7 @@
  * Group integration
  * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/__init__.py
  */
-import { IncludeNamed, IncludeList } from "../types";
+import { Data, IncludeNamed, IncludeList } from "../types";
 import { Action } from "../actions";
 
 export type Domain = "script";
@@ -68,6 +68,12 @@ interface Item {
     | "error"
     | "fatal"
     | "critical";
+
+  /**
+   * Variables that will be available inside your templates.
+   * https://www.home-assistant.io/integrations/script/#variables
+   */
+  variables?: Data;
 
   /**
    * The sequence of actions to be performed in the script.


### PR DESCRIPTION
This PR adds support for the new variables options for scripts and automation, introduced in Home Assistant 0.115.

It adds the new options to script/automations and adds the new `variabels` action.

Upstream PRs:
- https://github.com/home-assistant/core/pull/39895
- https://github.com/home-assistant/core/pull/39915
