### PR TITLE
Add the ability to reload bayesian integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,6 +208,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.bayesianReload",
+        "title": "Reload Bayesian",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -221,6 +221,11 @@ export async function activate(
       "reload"
     ),
     new CommandMappings(
+      "vscode-home-assistant.bayesianReload",
+      "bayesian",
+      "reload"
+    ),
+    new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
       "addon_restart",


### PR DESCRIPTION
Add support for reloading the bayesian integration, added in Home Assistant 0.115

Upstream PR: https://github.com/home-assistant/core/pull/39771

closes #600
