### PR TITLE
Add the ability to reload telegram integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,6 +213,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.telegramReload",
+        "title": "Reload Telegram",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -226,6 +226,11 @@ export async function activate(
       "reload"
     ),
     new CommandMappings(
+      "vscode-home-assistant.telegramReload",
+      "telegram",
+      "reload"
+    ),
+    new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
       "addon_restart",


### PR DESCRIPTION
Adds the ability to reload the Telegram integration (which reload the notify platform). This is added in Home Assistant 0.115

Upstream PR: <https://github.com/home-assistant/core/pull/39529>

closes #589