### PR TITLE
Add the ability to reload smtp integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,6 +218,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.smtpReload",
+        "title": "Reload SMTP",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -230,6 +230,7 @@ export async function activate(
       "telegram",
       "reload"
     ),
+    new CommandMappings("vscode-home-assistant.smtpReload", "smpt", "reload"),
     new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",


### PR DESCRIPTION
Adds the ability to reload the smtp integration, which is added in Home Assistant 0.115

Upstream PR: https://github.com/home-assistant/core/pull/39530

closes #588