### PR TITLE
Add the ability to reload mqtt integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,6 +223,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.mqttReload",
+        "title": "Reload MQTT",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -230,7 +230,8 @@ export async function activate(
       "telegram",
       "reload"
     ),
-    new CommandMappings("vscode-home-assistant.smtpReload", "smpt", "reload"),
+    new CommandMappings("vscode-home-assistant.smtpReload", "smtp", "reload"),
+    new CommandMappings("vscode-home-assistant.smtpReload", "mqtt", "reload"),
     new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",


### PR DESCRIPTION
Added the ability to reload the MQTT integration. This was added in Home Assistant 0.115

upstream PR: https://github.com/home-assistant/core/pull/39531

closes #586