### PR TITLE
Add the ability to reload rpi_gpio integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -228,6 +228,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.rpioGpioReload",
+        "title": "Reload Raspberry Pi GPIO",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -231,7 +231,12 @@ export async function activate(
       "reload"
     ),
     new CommandMappings("vscode-home-assistant.smtpReload", "smtp", "reload"),
-    new CommandMappings("vscode-home-assistant.smtpReload", "mqtt", "reload"),
+    new CommandMappings("vscode-home-assistant.mqttReload", "mqtt", "reload"),
+    new CommandMappings(
+      "vscode-home-assistant.rpioGpioReload",
+      "rpi_gpio",
+      "reload"
+    ),
     new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",


### PR DESCRIPTION
Adds the ability to reload the YAML configuration of the Raspberry Pi GPIO integration. This has been added in Home Assistant 0.115.

Upstream parent PR: <https://github.com/home-assistant/core/pull/39548>

closes #583