### PR TITLE
Fix allow group integration without groups

### DIFF
--- a/src/language-service/src/schemas/homeassistant.ts
+++ b/src/language-service/src/schemas/homeassistant.ts
@@ -34,7 +34,7 @@ export interface InternalIntegrations {
    * Groups allows you to combine multiple entities into a single group entity.
    * https://www.home-assistant.io/integrations/group
    */
-  group?: integrations.Group.Schema | IncludeNamed;
+  group?: integrations.Group.Schema | IncludeNamed | null;
 
   /**
    * The http integration serves all files and data required for the Home Assistant frontend. You only need to add this to your configuration file if you want to change any of the default settings.


### PR DESCRIPTION
Allow for setting up the group integration, without adding groups.
For example:

```yaml
group: ~
```

fixes #656