### PR TITLE
Fix missing name property for Media Control card

### DIFF
--- a/src/language-service/src/schemas/ui-lovelace.ts
+++ b/src/language-service/src/schemas/ui-lovelace.ts
@@ -314,6 +314,7 @@ export interface MarkdownCardConfig extends LovelaceCardConfig {
 export interface MediaControlCardConfig extends LovelaceCardConfig {
   type: "media-control";
   entity: string;
+  name?: string;
 }
 
 export interface PictureCardConfig extends LovelaceCardConfig {


### PR DESCRIPTION
fixes #641