### PR TITLE
Accept secrets everywhere

### DIFF
--- a/src/language-service/src/schemas/core.ts
+++ b/src/language-service/src/schemas/core.ts
@@ -4,7 +4,6 @@ import {
   DeviceClasses,
   IncludeNamed,
   Integer,
-  Secret,
   TimeZone,
   UnitSystem,
 } from "./types";
@@ -17,13 +16,13 @@ export interface Core {
    * List of folders that can be used as sources for files.
    * https://www.home-assistant.io/docs/configuration/basic/#allowlist_external_dirs
    */
-  allowlist_external_dirs?: string[] | Secret[];
+  allowlist_external_dirs?: string[];
 
   /**
    * List of URLs that can be used as sources for files.
    * https://www.home-assistant.io/docs/configuration/basic/#allowlist_external_urls
    */
-  allowlist_external_urls?: string[] | Secret[];
+  allowlist_external_urls?: string[];
 
   /**
    * Customize entities.
@@ -47,19 +46,19 @@ export interface Core {
    * Altitude above sea level in meters. Impacts weather/sunrise data.
    * https://www.home-assistant.io/docs/configuration/basic/#elevation
    */
-  elevation?: Integer | Secret;
+  elevation?: Integer;
 
   /**
    * The URL that Home Assistant is available on from the internet. For example: https://example.duckdns.org:8123. Note that this setting may only contain a protocol, hostname and port; using a path is not supported.
    * https://www.home-assistant.io/docs/configuration/basic/#external_url
    */
-  external_url?: string | Secret;
+  external_url?: string;
 
   /**
    * The URL that Home Assistant is available on from your local network. For example: http://homeassistant.local:8123. Note that this setting may only contain a protocol, hostname and port; using a path is not supported.
    * https://www.home-assistant.io/docs/configuration/basic/#internal_url
    */
-  internal_url?: string | Secret;
+  internal_url?: string;
 
   /**
    * Latitude of your location required to calculate the time the sun rises and sets.
@@ -68,7 +67,7 @@ export interface Core {
    * @minimum -90
    * @maximum 90
    */
-  latitude?: number | Secret;
+  latitude?: number;
 
   /**
    * Longitude of your location required to calculate the time the sun rises and sets.
@@ -77,13 +76,13 @@ export interface Core {
    * @minimum -180
    * @maximum 180
    */
-  longitude?: number | Secret;
+  longitude?: number;
 
   /**
    * Name of the location where Home Assistant is running.
    * https://www.home-assistant.io/docs/configuration/basic/#name
    */
-  name?: string | Secret;
+  name?: string;
 
   /**
    * Packages in Home Assistant provide a way to bundle different component’s configuration together. It allows for "splitting" your configuration.
@@ -96,14 +95,14 @@ export interface Core {
    * https://www.home-assistant.io/docs/configuration/basic/#time_zone
    * https://www.wikiwand.com/en/List_of_tz_database_time_zones
    */
-  time_zone?: TimeZone | Secret;
+  time_zone?: TimeZone;
 
   /**
    * "metric" for Metric, "imperial" for Imperial.
    * This also sets temperature unit Home Assistant will use.
    * https://www.home-assistant.io/docs/configuration/basic/#unit_system
    */
-  unit_system?: UnitSystem | Secret;
+  unit_system?: UnitSystem;
 
   /**
    * DEPRECATED as of Home Assistant 0.113.0.

--- a/src/language-service/src/schemas/integrations/hacs.ts
+++ b/src/language-service/src/schemas/integrations/hacs.ts
@@ -3,8 +3,6 @@
  * https://hacs.xyz/
  * Source: https://github.com/hacs/integration/blob/1.1.2/custom_components/hacs/configuration_schema.py
  */
-import { Secret } from "../types";
-
 export type Domain = "hacs";
 export interface Schema {
   /**
@@ -13,7 +11,7 @@ export interface Schema {
    *
    * @TJS-pattern ^[0-9a-fA-F]{40}$
    */
-  token: string | Secret;
+  token: string;
 
   /**
    * Enable tracking of AppDaemon apps.

--- a/src/language-service/src/schemas/integrations/http.ts
+++ b/src/language-service/src/schemas/integrations/http.ts
@@ -2,13 +2,7 @@
  * HTTP ntegration
  * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/http/__init__.py
  */
-import {
-  Deprecated,
-  IncludeList,
-  Port,
-  PositiveInteger,
-  Secret,
-} from "../types";
+import { Deprecated, IncludeList, Port, PositiveInteger } from "../types";
 
 export type Domain = "http";
 export interface Schema {
@@ -22,7 +16,7 @@ export interface Schema {
    * A list of origin domain names to allow CORS requests from. Enabling this will set the Access-Control-Allow-Origin header to the Origin header if it is found in the list, and the Access-Control-Allow-Headers header to Origin, Accept, X-Requested-With, Content-type, Authorization.
    * https://www.home-assistant.io/integrations/http#cors_allowed_origins
    */
-  cors_allowed_origins?: string | string[] | Secret | Secret[] | IncludeList;
+  cors_allowed_origins?: string | string[] | IncludeList;
 
   /**
    * Flag indicating whether additional IP filtering is enabled.
@@ -41,7 +35,7 @@ export interface Schema {
    * Warning! Only use this option when you run Home Assistant Core directly in Python!
    * https://www.home-assistant.io/integrations/http#server_host
    */
-  server_host?: string | Secret;
+  server_host?: string;
 
   /**
    * Let you set a port for Home Assistant to run on.
@@ -53,19 +47,19 @@ export interface Schema {
    * Path to your TLS/SSL certificate to serve Home Assistant over a secure connection.
    * https://www.home-assistant.io/integrations/http#ssl_certificate
    */
-  ssl_certificate?: string | Secret;
+  ssl_certificate?: string;
 
   /**
    * Path to your TLS/SSL key to serve Home Assistant over a secure connection.
    * https://www.home-assistant.io/integrations/http#ssl_key
    */
-  ssl_key?: string | Secret;
+  ssl_key?: string;
 
   /**
    * Path to the client/peer TLS/SSL certificate to accept secure connections from.
    * https://www.home-assistant.io/integrations/http#ssl_peer_certificate
    */
-  ssl_peer_certificate?: string | Secret;
+  ssl_peer_certificate?: string;
 
   /**
    * The Mozilla SSL profile to use. Only lower if you are experiencing integrations causing SSL handshake errors.
@@ -85,7 +79,7 @@ export interface Schema {
    * This option should be handled and set with extreme care!
    * https://www.home-assistant.io/integrations/http#trusted_proxies
    */
-  trusted_proxies?: string | string[] | Secret | Secret[] | IncludeList;
+  trusted_proxies?: string | string[] | IncludeList;
 
   /**
    * Enable parsing of the X-Forwarded-For header, passing on the client’s correct IP address in proxied setups. You must also whitelist trusted proxies using the trusted_proxies setting for this to work. Non-whitelisted requests with this header will be considered IP spoofing attacks, and the header will, therefore, be ignored.

--- a/src/language-service/src/schemas/integrations/panel_iframe.ts
+++ b/src/language-service/src/schemas/integrations/panel_iframe.ts
@@ -2,7 +2,7 @@
  * iframe Panel integration
  * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/panel_iframe/__init__.py
  */
-import { IncludeNamed, Secret } from "../types";
+import { IncludeNamed } from "../types";
 
 export type Domain = "panel_iframe";
 export interface Schema {
@@ -34,5 +34,5 @@ interface Item {
    *
    * @TJS-format uri
    */
-  url: string | Secret;
+  url: string;
 }

--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -212,18 +212,6 @@ export type PositiveInteger = number;
  */
 export type Port = number;
 
-/**
- * @TJS-pattern ^!secret\s([a-zA-Z0-9_-]+)$
- */
-export type Secret = string;
-
-/**
- * @TJS-type string
- * @TJS-pattern [.]yaml|[.]yml$
- */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SecretTag {}
-
 export type State = number | string;
 export type Template = string;
 


### PR DESCRIPTION
This PR ignores schema validation error thrown by `!secrets`.

At this point, we simply don't know what a secret is. Yet, we do throw warnings about them. There is a construct for allowing secrets on options, but it isn't ideal.

Home Assistant secrets are actually accepted ANYWHERE, meaning everything could be a string? That ain't pretty.

This patch ain't pretty either, but at least it makes us accept !secrets, everywhere, without the need for defining them in the schema.

Hopefully, we can replace this with a better construct in the future.


fixes #650
fixes #451
closes #538

Happy Hacktoberfest 🎉 