### PR TITLE
Add special row button for entities schema

### DIFF
--- a/src/language-service/src/schemas/ui-lovelace.ts
+++ b/src/language-service/src/schemas/ui-lovelace.ts
@@ -560,7 +560,7 @@ export interface ButtonEntityConfig {
   action_name?: string;
   tap_action: ActionConfig;
   hold_action?: ActionConfig;
-  double_tap_token?: ActionConfig;
+  double_tap_action?: ActionConfig;
 }
 
 /**

--- a/src/language-service/src/schemas/ui-lovelace.ts
+++ b/src/language-service/src/schemas/ui-lovelace.ts
@@ -208,6 +208,7 @@ export interface EntitiesCardConfig extends LovelaceCardConfig {
     | SectionEntityConfig
     | CastEntityConfig
     | CustomEntityConfig
+    | ButtonEntityConfig
     | string
   >;
   theme?: string;
@@ -550,6 +551,16 @@ export interface CastEntityConfig {
   name?: string;
   view: string | number;
   hide_if_unavailable?: boolean;
+}
+
+export interface ButtonEntityConfig {
+  type: "button";
+  name: string;
+  icon?: string;
+  action_name?: string;
+  tap_action: ActionConfig;
+  hold_action?: ActionConfig;
+  double_tap_token?: ActionConfig;
 }
 
 /**


### PR DESCRIPTION
Note that `icon` is not mentioned in the documentation here: https://www.home-assistant.io/lovelace/entities/
But it is used here in the latest source code: https://github.com/home-assistant/frontend/blob/96110637d935adc1c6278cc50319a6abc43eeb67/src/panels/lovelace/special-rows/hui-button-row.ts#L54
(I am meaning to update the Hass documentation.)

btw, could you please add topic "hacktoberfest"? 🙂 🙏
"Maintainers of the repository can add the "hacktoberfest" topic to their repository if they wish to participate."
https://hacktoberfest.digitalocean.com/
