### PR TITLE
Allow any type in state trigger

### DIFF
--- a/src/language-service/src/schemas/triggers.ts
+++ b/src/language-service/src/schemas/triggers.ts
@@ -229,13 +229,13 @@ interface StateTrigger {
    * The state the entity or entities had before changing to its new state.
    * https://www.home-assistant.io/docs/automation/trigger/#state-trigger
    */
-  from?: State | State[];
+  from?: any | any[];
 
   /**
    * The state the entity or entities have changed to.
    * https://www.home-assistant.io/docs/automation/trigger/#state-trigger
    */
-  to?: State | State[];
+  to?: any | any[];
 
   /**
    * Use the value of a specific entity attribute to trigger on, instead of the entity state.


### PR DESCRIPTION
With the introduction of having a state trigger with an attribute in 0.115, it became possible to check a attribute state against any type.

Entity state attributes are type aware (states are not), thus when using an attribute, the `from`/`to` could be something else as well, e.g., a boolean, float, or even a mapping.