### PR TITLE
Add schema for template binary sensor

### DIFF
--- a/src/language-service/src/schemas/homeassistant.ts
+++ b/src/language-service/src/schemas/homeassistant.ts
@@ -31,6 +31,12 @@ export interface InternalIntegrations {
   automation?: integrations.Automation.Schema | IncludeList;
 
   /**
+   * Binary sensors gather information about the state of devices which have a “digital” return value (either 1 or 0). These can be switches, contacts, pins, etc.
+   * https://www.home-assistant.io/integrations/binary_sensor
+   */
+  binary_sensor?: integrations.BinarySensor.Schema | IncludeList;
+
+  /**
    * The counter integration allows one to count occurrences fired by automations.
    * https://www.home-assistant.io/integrations/counter
    */

--- a/src/language-service/src/schemas/integrations/binary_sensor.ts
+++ b/src/language-service/src/schemas/integrations/binary_sensor.ts
@@ -1,0 +1,24 @@
+/**
+ * Binary Sensor integration
+ * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/binary_sensor/__init__.py
+ */
+import { IncludeList } from "../types";
+import { PlatformSchema } from "../platform";
+import { BinarySensorPlatformSchema as TemplatePlatformSchema } from "./template";
+
+export type Domain = "binary_sensor";
+export type Schema = Item[] | IncludeList;
+export type File = Item | Item[];
+
+/**
+ * @TJS-additionalProperties true
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface OtherPlatform extends PlatformSchema {
+  /**
+   * @TJS-pattern ^(?!template)\w+$
+   */
+  platform: string;
+}
+
+type Item = TemplatePlatformSchema | OtherPlatform;

--- a/src/language-service/src/schemas/integrations/index.d.ts
+++ b/src/language-service/src/schemas/integrations/index.d.ts
@@ -1,4 +1,5 @@
 export * as Automation from "./automation";
+export * as BinarySensor from "./binary_sensor";
 export * as Counter from "./counter";
 export * as Group from "./group";
 export * as HACS from "./hacs";

--- a/src/language-service/src/schemas/integrations/template.ts
+++ b/src/language-service/src/schemas/integrations/template.ts
@@ -1,0 +1,97 @@
+/**
+ * Template integration
+ * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/template/
+ */
+import {
+  Deprecated,
+  IncludeNamed,
+  Template,
+  DeviceClassesBinarySensor,
+  TimePeriod,
+} from "../types";
+import { PlatformSchema } from "../platform";
+
+export type Domain = "template";
+
+export interface BinarySensorPlatformSchema extends PlatformSchema {
+  /**
+   * The template platform supports binary sensors which get their values from other entities. The state of a Template Binary Sensor can only be on or off.
+   * https://www.home-assistant.io/integrations/binary_sensor.template
+   */
+  platform: "template";
+
+  /**
+   * List of sensors.
+   * https://www.home-assistant.io/integrations/binary_sensor.template#sensors
+   */
+  sensors: {
+    [key: string]: BinarySensorItem | IncludeNamed;
+  };
+}
+
+interface BinarySensorItem {
+  /**
+   * Defines templates for attributes of the sensor.
+   * https://www.home-assistant.io/integrations/binary_sensor.template#attribute_templates
+   */
+  attribute_templates?: { [key: string]: Template };
+
+  /**
+   * Defines a template to get the available state of the sensor. Return true if the device is available, false otherwise.
+   * https://www.home-assistant.io/integrations/binary_sensor.template#availability_template
+   */
+  availability_template?: Template;
+
+  /**
+   * The amount of time the template state must be not met before this sensor will switch to off.
+   * https://www.home-assistant.io/integrations/binary_sensor.template#delay_off
+   */
+  delay_off?: TimePeriod;
+
+  /**
+   * The amount of time the template state must be met before this sensor will switch to on.
+   * https://www.home-assistant.io/integrations/binary_sensor.template#delay_on
+   */
+  delay_on?: TimePeriod;
+
+  /**
+   * Sets the class of the device, changing the device state and icon that is displayed on the frontend.
+   * https://www.home-assistant.io/integrations/binary_sensor.template#device_class
+   */
+  device_class?: DeviceClassesBinarySensor;
+
+  /**
+   * DEPRECATED as of Home Assistant 0.115.0
+   */
+  entity_id?: Deprecated;
+
+  /**
+   * Defines a template for the entity picture of the sensor.
+   * https://www.home-assistant.io/integrations/binary_sensor.template#entity_picture_template
+   */
+  entity_picture_template?: Template;
+
+  /**
+   * Name to use in the frontend.
+   * https://www.home-assistant.io/integrations/binary_sensor.template#friendly_name
+   */
+  friendly_name?: string;
+
+  /**
+   * Defines a template for the icon of the sensor.
+   * https://www.home-assistant.io/integrations/binary_sensor.template#icon_template
+   */
+  icon_template?: Template;
+
+  /**
+   * An ID that uniquely identifies this binary sensor. Set this to an unique value to allow customization through the UI.
+   * https://www.home-assistant.io/integrations/binary_sensor.template#unique_id
+   */
+  unique_id?: string;
+
+  /**
+   * The sensor is on if the template evaluates as True and off otherwise.
+   * https://www.home-assistant.io/integrations/binary_sensor.template#value_template
+   */
+  value_template: Template;
+}

--- a/src/language-service/src/schemas/mappings.json
+++ b/src/language-service/src/schemas/mappings.json
@@ -70,6 +70,13 @@
     "fromType": "File"
   },
   {
+    "key": "binary_sensor",
+    "path": "configuration.yaml/binary_sensor",
+    "file": "binary_sensor.json",
+    "tsFile": "integrations/binary_sensor.ts",
+    "fromType": "File"
+  },
+  {
     "key": "ui-lovelace",
     "path": "ui-lovelace.yaml",
     "file": "ui-lovelace.json",

--- a/src/language-service/src/schemas/platform.ts
+++ b/src/language-service/src/schemas/platform.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared platform entity models
+ */
+
+import { TimePeriod } from "./types";
+
+export interface PlatformSchema {
+  /**
+   * Platform domain
+   */
+  platform: string;
+
+  /**
+   * By setting an entity namespace, all entities will be prefixed with that namespace.
+   * https://www.home-assistant.io/docs/configuration/platform_options/#entity-namespace
+   */
+  entity_namespace?: string;
+
+  /**
+   * Allow to change the polling interval if the platform uses a polling mechanism.
+   * https://www.home-assistant.io/docs/configuration/platform_options/#scan-interval
+   */
+  scan_interval?: TimePeriod;
+}


### PR DESCRIPTION
Adds support for the binary sensor platform of the template integration. This is a platform only, thus this PR implements some structure for the platform schema-based integration as well.