### PR TITLE
Fix typo in input_number mode property

### DIFF
--- a/src/language-service/src/schemas/integrations/input_number.ts
+++ b/src/language-service/src/schemas/integrations/input_number.ts
@@ -14,7 +14,7 @@ interface Item {
    * Show a "slider" or a input "box" in the UI frontend. Defaults to "slider".
    * https://www.home-assistant.io/integrations/input_number#mode
    */
-  conf_mode?: "slider" | "box";
+  mode?: "slider" | "box";
 
   /**
    * The icon that shows in the frontend.


### PR DESCRIPTION
Fixes a typo in the `mode` property of the `input_number` integration, causing it to fail validation.

fixes #705 
