### PR TITLE
Fix regular expression in known platforms

### DIFF
--- a/src/language-service/src/schemas/integrations/alarm_control_panel.ts
+++ b/src/language-service/src/schemas/integrations/alarm_control_panel.ts
@@ -15,7 +15,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!template)\w+$
+   * @TJS-pattern ^(?!(template)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/binary_sensor.ts
+++ b/src/language-service/src/schemas/integrations/binary_sensor.ts
@@ -16,7 +16,7 @@ export type File = Item | Item[];
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!template)\w+$
+   * @TJS-pattern ^(?!(template)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/cover.ts
+++ b/src/language-service/src/schemas/integrations/cover.ts
@@ -15,7 +15,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!template)\w+$
+   * @TJS-pattern ^(?!(template)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/fan.ts
+++ b/src/language-service/src/schemas/integrations/fan.ts
@@ -15,7 +15,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!template)\w+$
+   * @TJS-pattern ^(?!(template)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/light.ts
+++ b/src/language-service/src/schemas/integrations/light.ts
@@ -15,7 +15,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!template)\w+$
+   * @TJS-pattern ^(?!(template)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/lock.ts
+++ b/src/language-service/src/schemas/integrations/lock.ts
@@ -15,7 +15,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!template)\w+$
+   * @TJS-pattern ^(?!(template)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/sensor.ts
+++ b/src/language-service/src/schemas/integrations/sensor.ts
@@ -16,7 +16,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!mqtt|template)\w+$
+   * @TJS-pattern ^(?!(mqtt|template)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/switch.ts
+++ b/src/language-service/src/schemas/integrations/switch.ts
@@ -15,7 +15,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!template)\w+$
+   * @TJS-pattern ^(?!(template)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/vacuum.ts
+++ b/src/language-service/src/schemas/integrations/vacuum.ts
@@ -15,7 +15,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!template)\w+$
+   * @TJS-pattern ^(?!(template)$)\w+$
    */
   platform: string;
 }


### PR DESCRIPTION
The regular expressions used for known platforms integration was to loose, causing it to mistake `mqtt_room` for the `mqtt` integration.

This PR adjusts the regular expression used to be more strict and only matches against the known platforms.

fixes #704