### PR TITLE
Add cloud schema support

### DIFF
--- a/src/language-service/src/completionHelpers/entityIds.ts
+++ b/src/language-service/src/completionHelpers/entityIds.ts
@@ -11,6 +11,7 @@ export class EntityIdCompletionContribution implements JSONWorkerContribution {
     "badges",
     "devices",
     "entities",
+    "entity_config",
     "entity_id",
     "entity",
     "exclude_entities",

--- a/src/language-service/src/schemas/homeassistant.ts
+++ b/src/language-service/src/schemas/homeassistant.ts
@@ -155,6 +155,12 @@ export interface InternalIntegrations {
  */
 export interface CoreIntegrations {
   /**
+   * The Home Assistant Cloud allows you to quickly integrate your local Home Assistant with various cloud services like Amazon Alexa and Google Assistant.
+   * https://www.nabucasa.com/config/
+   */
+  cloud?: integrations.Cloud.Schema | IncludeNamed | null;
+
+  /**
    * DEPRECATED as of Home Assistant 0.113.0
    *
    * The Philips Hue integration allows you to control and monitor the lights and motion sensors connected to your Hue bridge.

--- a/src/language-service/src/schemas/integrations/cloud.ts
+++ b/src/language-service/src/schemas/integrations/cloud.ts
@@ -113,7 +113,7 @@ interface Filter {
   /**
    * The list of domains to be excluded.
    */
-  exclude_domains: Domains;
+  exclude_domains?: Domains;
 
   /**
    * The list of entity ids to be excluded,
@@ -123,7 +123,7 @@ interface Filter {
   /**
    * Exclude all entities matching a listed pattern (e.g., switch.garage_*).
    */
-  exclude_entity_globs: string[];
+  exclude_entity_globs?: string[];
 
   /**
    * The list of domains to be included.
@@ -138,7 +138,7 @@ interface Filter {
   /**
    * Include all entities matching a listed pattern (e.g., light.living_room_*).
    */
-  include_entity_globs: string[];
+  include_entity_globs?: string[];
 }
 
 interface AlexaEntity {

--- a/src/language-service/src/schemas/integrations/cloud.ts
+++ b/src/language-service/src/schemas/integrations/cloud.ts
@@ -1,0 +1,223 @@
+/**
+ * Cloud integration
+ * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/cloud/__init__.py
+ */
+import { Domains, Entities, IncludeNamed } from "../types";
+
+export type Domain = "cloud";
+
+export interface Schema {
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  account_link_url?: string;
+
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  acme_directory_server?: string;
+
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  alexa_access_token_url?: string;
+
+  /**
+   * Configure the Amazon Alexa integration.
+   * https://www.nabucasa.com/config/amazon_alexa/
+   */
+  alexa?: {
+    /**
+     * Filters for entities to include/exclude from Alexa.
+     * https://www.nabucasa.com/config/amazon_alexa/
+     */
+    filter?: Filter;
+
+    /**
+     * Entity specific configuration for Alexa.
+     * https://www.nabucasa.com/config/amazon_alexa/
+     */
+    entity_config?: { [key: string]: AlexaEntity } | IncludeNamed;
+  };
+
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  cloudhook_create_url?: string;
+
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  cognito_client_id?: string;
+
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  google_actions_report_state_url?: string;
+
+  /**
+   * The Google Assistant integration allows users to control the entities via the Home Assistant Smart Home skill for Google Assistant.
+   * https://www.nabucasa.com/config/google_assistant/
+   */
+  google_actions?: {
+    /**
+     * Filters for entities to include/exclude from Google Assistant.
+     * https://www.nabucasa.com/config/google_assistant/
+     */
+    filter?: Filter;
+
+    /**
+     * Entity specific configuration for Google Assistant.
+     * https://www.nabucasa.com/config/google_assistant/
+     */
+    entity_config?: { [key: string]: GoogleEntity } | IncludeNamed;
+  };
+
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  mode?: "production" | "development";
+
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  region?: string;
+
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  relayer?: string;
+
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  remote_api_url?: string;
+
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  subscription_info_url?: string;
+
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  user_pool_id?: string;
+
+  /**
+   * This option is for development, you do not need it in general.
+   */
+  voice_api_url?: string;
+}
+
+interface Filter {
+  /**
+   * The list of domains to be excluded.
+   */
+  exclude_domains: Domains;
+
+  /**
+   * The list of entity ids to be excluded,
+   */
+  exclude_entities?: Entities;
+
+  /**
+   * Exclude all entities matching a listed pattern (e.g., switch.garage_*).
+   */
+  exclude_entity_globs: string[];
+
+  /**
+   * The list of domains to be included.
+   */
+  include_domains?: Domains;
+
+  /**
+   * The list of entity ids to be included.
+   */
+  include_entities?: Entities;
+
+  /**
+   * Include all entities matching a listed pattern (e.g., light.living_room_*).
+   */
+  include_entity_globs: string[];
+}
+
+interface AlexaEntity {
+  /**
+   * Description of entity to show in Alexa.
+   */
+  description?: string;
+
+  /**
+   * The display category to use in Alexa.
+   * Available categories: https://developer.amazon.com/en-US/docs/alexa/device-apis/alexa-discovery.html#display-categories
+   */
+  display_categories?:
+    | "ACTIVITY_TRIGGER"
+    | "AIR_FRESHENER"
+    | "AIR_PURIFIER"
+    | "AUTO_ACCESSORY"
+    | "CAMERA"
+    | "CHRISTMAS_TREE"
+    | "COFFEE_MAKER"
+    | "COMPUTER"
+    | "CONTACT_SENSOR"
+    | "DOOR"
+    | "DOORBELL"
+    | "EXTERIOR_BLIND"
+    | "FAN"
+    | "GAME_CONSOLE"
+    | "GARAGE_DOOR"
+    | "HEADPHONES"
+    | "HUB"
+    | "INTERIOR_BLIND"
+    | "LAPTOP"
+    | "LIGHT"
+    | "MICROWAVE"
+    | "MOBILE_PHONE"
+    | "MOTION_SENSOR"
+    | "MUSIC_SYSTEM"
+    | "NETWORK_HARDWARE"
+    | "OTHER"
+    | "OVEN"
+    | "PHONE"
+    | "PRINTER"
+    | "ROUTE"
+    | "SCENE_TRIGGER"
+    | "SCREEN"
+    | "SECURITY_PANEL"
+    | "SECURITY_SYSTEM"
+    | "SLOW_COOKER"
+    | "SMARTLOCK"
+    | "SMARTPLUG"
+    | "SPEAKER"
+    | "STREAMING_DEVICE"
+    | "SWITCH"
+    | "TABLET"
+    | "TEMPERATURE_SENSOR"
+    | "THERMOSTAT"
+    | "TV"
+    | "VACUUM_CLEANER"
+    | "WEARABLE";
+
+  /**
+   * Name of entity to show in Alexa.
+   */
+  name?: string;
+}
+
+interface GoogleEntity {
+  /**
+   * Aliases that can also be used to refer to this entity.
+   */
+  aliases?: string | string[];
+
+  /**
+   * Name of entity to show in Google Assistant.
+   */
+  name?: string;
+
+  /**
+   * Hint for Google Assistant in which room this entity is.
+   */
+  room?: string;
+}

--- a/src/language-service/src/schemas/integrations/index.d.ts
+++ b/src/language-service/src/schemas/integrations/index.d.ts
@@ -3,6 +3,7 @@ export * as Automation from "./automation";
 export * as BinarySensor from "./binary_sensor";
 export * as Camera from "./camera";
 export * as Climate from "./climate";
+export * as Cloud from "./cloud";
 export * as Counter from "./counter";
 export * as Cover from "./cover";
 export * as DeviceTracker from "./device_tracker";


### PR DESCRIPTION
Add schema support for cloud integration.

Also adds auto-completion on the `entity_config` key for entity IDs (used in multiple places).

![2020-10-10 15 59 50](https://user-images.githubusercontent.com/195327/95657045-a7f37800-0b12-11eb-96a6-54302c3e9125.gif)
