### PR TITLE
Fix initial value type for input_number

### DIFF
--- a/src/language-service/src/schemas/integrations/input_number.ts
+++ b/src/language-service/src/schemas/integrations/input_number.ts
@@ -26,7 +26,7 @@ interface Item {
    * Initial value when Home Assistant starts.
    * https://www.home-assistant.io/integrations/input_number#initial
    */
-  initial?: boolean;
+  initial?: number;
 
   /**
    * Maximum value of the number


### PR DESCRIPTION
The `initial` value of `input_number` was set as a boolean, however, for the `input_number` this should be a number.

Fixes #716