### PR TITLE
Add new legacy_templates core option for 0.117

### DIFF
--- a/src/language-service/src/schemas/core.ts
+++ b/src/language-service/src/schemas/core.ts
@@ -70,6 +70,12 @@ export interface Core {
   latitude?: number;
 
   /**
+   * Enable this option to restore pre-0.117 template rendering. Which renders all templates to string, instead of native types.
+   * https://www.home-assistant.io/docs/configuration/basic/#legacy_templates
+   */
+  legacy_templates?: boolean;
+
+  /**
    * Longitude of your location required to calculate the time the sun rises and sets.
    * https://www.home-assistant.io/docs/configuration/basic/#longitude
    *


### PR DESCRIPTION
Home Assistant 0.117 introduces native types for templates.

This new core option is introduced, allowing users to restore the old behavior until they are ready to upgrade to the new behavior.