### PR TITLE
Add Tag trigger

### DIFF
--- a/src/language-service/src/schemas/triggers.ts
+++ b/src/language-service/src/schemas/triggers.ts
@@ -28,7 +28,8 @@ export type Trigger =
   | TimeTrigger
   | TimePatternTrigger
   | WebhookTrigger
-  | ZoneTrigger;
+  | ZoneTrigger
+  | TagTrigger;
 
 /**
  * @TJS-additionalProperties true
@@ -370,4 +371,9 @@ interface ZoneTrigger {
    * https://www.home-assistant.io/docs/automation/trigger/#zone-trigger
    */
   event: "enter" | "leave";
+}
+
+interface TagTrigger {
+  platform: "tag";
+  tag_id: string;
 }

--- a/src/language-service/src/schemas/triggers.ts
+++ b/src/language-service/src/schemas/triggers.ts
@@ -24,12 +24,12 @@ export type Trigger =
   | NumericStateTrigger
   | StateTrigger
   | SunTrigger
+  | TagTrigger
   | TemplateTrigger
   | TimeTrigger
   | TimePatternTrigger
   | WebhookTrigger
-  | ZoneTrigger
-  | TagTrigger;
+  | ZoneTrigger;
 
 /**
  * @TJS-additionalProperties true

--- a/src/language-service/src/schemas/triggers.ts
+++ b/src/language-service/src/schemas/triggers.ts
@@ -376,16 +376,19 @@ interface ZoneTrigger {
 interface TagTrigger {
   /**
    * This trigger fired when a tag is scanned.
+   * https://www.home-assistant.io/docs/automation/trigger#tag-trigger
    */
   platform: "tag";
 
   /**
    * Identifier of the tag. Use this to decide what to do.
+   * https://www.home-assistant.io/docs/automation/trigger#tag-trigger
    */
   tag_id: string;
 
   /**
    * Device registry identifier of the device that scanned the tag. Use this to decide where to do it.
+   * https://www.home-assistant.io/docs/automation/trigger#tag-trigger
    */
   device_id?: string;
 }

--- a/src/language-service/src/schemas/triggers.ts
+++ b/src/language-service/src/schemas/triggers.ts
@@ -374,7 +374,6 @@ interface ZoneTrigger {
 }
 
 interface TagTrigger {
-
   /**
    * This trigger fired when a tag is scanned.
    */

--- a/src/language-service/src/schemas/triggers.ts
+++ b/src/language-service/src/schemas/triggers.ts
@@ -374,6 +374,19 @@ interface ZoneTrigger {
 }
 
 interface TagTrigger {
+
+  /**
+   * This trigger fired when a tag is scanned.
+   */
   platform: "tag";
+
+  /**
+   * Identifier of the tag. Use this to decide what to do.
+   */
   tag_id: string;
+
+  /**
+   * Device registry identifier of the device that scanned the tag. Use this to decide where to do it.
+   */
+  device_id?: string;
 }


### PR DESCRIPTION
Sorry for the missing documentation, but the tag documentation is missing: https://www.home-assistant.io/docs/automation/trigger
It's why I created this PR as a draft.

Automation generated by the UI when selecting a tag.

```YAML
- id: "1603278086586"
  alias: La balise a7e166cb-2df9-4e99-92e8-08357e611ba5 est analysée
  description: ""
  trigger:
    - platform: tag
      tag_id: a7e166cb-2df9-4e99-92e8-08357e611ba5
  condition: []
  action:
    - service: switch.turn_on
      data:
        entity_id: switch.music
  mode: single

```