### PR TITLE
Downgrade json languageservice to 3.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4034,9 +4034,9 @@
       }
     },
     "vscode-json-languageservice": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.10.0.tgz",
-      "integrity": "sha512-8IvuRSQnjznu+obqy6Dy4S4H68Ke7a3Kb+A0FcdctyAMAWEnrORpCpMOMqEYiPLm/OTYLVWJ7ql3qToDTozu4w==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.9.1.tgz",
+      "integrity": "sha512-oJkknkdCVitQ5XPSRa0weHjUxt8eSCptaL+MBQQlRsa6Nb8XnEY0S5wYnLUFHzEvKzwt01/LKk8LdOixWEXkNA==",
       "requires": {
         "jsonc-parser": "^2.3.1",
         "vscode-languageserver-textdocument": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -339,7 +339,7 @@
     "home-assistant-js-websocket": "^5.7.0",
     "utf-8-validate": "^5.0.3",
     "vscode-extension-telemetry": "0.1.6",
-    "vscode-json-languageservice": "3.10.0",
+    "vscode-json-languageservice": "^3.9.1",
     "vscode-languageclient": "6.1.3",
     "vscode-languageserver": "6.1.1",
     "vscode-languageserver-protocol": "3.15.3",

--- a/src/language-service/package-lock.json
+++ b/src/language-service/package-lock.json
@@ -3167,9 +3167,9 @@
       }
     },
     "vscode-json-languageservice": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.10.0.tgz",
-      "integrity": "sha512-8IvuRSQnjznu+obqy6Dy4S4H68Ke7a3Kb+A0FcdctyAMAWEnrORpCpMOMqEYiPLm/OTYLVWJ7ql3qToDTozu4w==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.9.1.tgz",
+      "integrity": "sha512-oJkknkdCVitQ5XPSRa0weHjUxt8eSCptaL+MBQQlRsa6Nb8XnEY0S5wYnLUFHzEvKzwt01/LKk8LdOixWEXkNA==",
       "requires": {
         "jsonc-parser": "^2.3.1",
         "vscode-languageserver-textdocument": "^1.0.1",

--- a/src/language-service/package.json
+++ b/src/language-service/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "axios": "^0.21.0",
     "home-assistant-js-websocket": "^5.7.0",
-    "vscode-json-languageservice": "^3.7.0",
+    "vscode-json-languageservice": "3.9.1",
     "vscode-languageserver-protocol": "3.15.3",
     "vscode-uri": "2.1.2",
     "ws": "7.3.1",


### PR DESCRIPTION
The upgrade to 3.10.0 currently breaks.

Changes: <https://github.com/microsoft/vscode-json-languageservice/compare/v3.9.0...v3.10.0>

We need to adjust the way we find/provide definitions.
For now, a quick downgrade to keep the codebase in a working state.