### PR TITLE
Exclude dependency upgrades from generated release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,10 +23,10 @@ categories:
   - title: "🧰 Maintenance"
     labels:
       - "chore"
-      - "dependencies"
 exclude-labels:
   - "invalid"
   - "wontfix"
+  - "dependencies"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 version-resolver:
   major:


### PR DESCRIPTION
This PR adjusts the release drafter, so it excludes PRs with automated dependency upgrades from the generated release notes.

It generates quite a bit of junk (welcome to the world of NPM? 😂 )