### PR TITLE
Fix MQTT device tracker devices list

### DIFF
--- a/src/language-service/src/schemas/integrations/mqtt.ts
+++ b/src/language-service/src/schemas/integrations/mqtt.ts
@@ -1367,7 +1367,7 @@ export interface DeviceTrackerPlatformSchema extends PlatformSchema {
    * List of devices with their topic.
    * https://www.home-assistant.io/integrations/device_tracker.mqtt/#devices
    */
-  devices: { [key: string]: string }[];
+  devices: { [key: string]: string };
 
   /**
    * The payload value that represents the ‘home’ state for the device.


### PR DESCRIPTION
This PR fixes a bug in the MQTT schema's of the device tracker platform.

MQTT expects a dictionary for devices, not a list of dictionaries.

fixes #729