### PR TITLE
Add support for media_dirs core configuration

### DIFF
--- a/src/language-service/src/schemas/core.ts
+++ b/src/language-service/src/schemas/core.ts
@@ -85,6 +85,12 @@ export interface Core {
   longitude?: number;
 
   /**
+   * A mapping of local media sources and their paths on disk.
+   * https://www.home-assistant.io/docs/configuration/basic/#media_dirs
+   */
+  media_dirs?: { [key: string]: string };
+
+  /**
    * Name of the location where Home Assistant is running.
    * https://www.home-assistant.io/docs/configuration/basic/#name
    */


### PR DESCRIPTION
Add support for the recently introduced `media_dirs` Home Assistant core configuration.

Closes #812