### PR TITLE
Add placeholder tag support

### DIFF
--- a/src/language-service/src/haConfig/haYamlFile.ts
+++ b/src/language-service/src/haConfig/haYamlFile.ts
@@ -95,6 +95,8 @@ export class HomeAssistantYamlFile {
 
   private getCustomTags(): Schema.Tag[] {
     return [
+      `env_Var`,
+      `placeholder`,
       `secret`,
       `${Includetype[Includetype.include]}`,
       `${Includetype[Includetype.include_dir_list]}`,

--- a/src/language-service/src/haLanguageService.ts
+++ b/src/language-service/src/haLanguageService.ts
@@ -77,8 +77,9 @@ export class HomeAssistantLanguageService {
         validTags.push(`!${item} scalar`);
       }
     }
-    validTags.push("!secret scalar");
     validTags.push("!env_var scalar");
+    validTags.push("!placeholder scalar");
+    validTags.push("!secret scalar");
 
     return validTags;
   }


### PR DESCRIPTION
This PR adds support for the new `!placeholder var_name` tag, that is introduced in Home Assistant 0.119