### PR TITLE
Add support for multiple tags/devices in a single trigger

### DIFF
--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -396,11 +396,11 @@ interface TagTrigger {
    * Identifier of the tag. Use this to decide what to do.
    * https://www.home-assistant.io/docs/automation/trigger#tag-trigger
    */
-  tag_id: string;
+  tag_id: string | string[];
 
   /**
    * Device registry identifier of the device that scanned the tag. Use this to decide where to do it.
    * https://www.home-assistant.io/docs/automation/trigger#tag-trigger
    */
-  device_id?: string;
+  device_id?: string | string[];
 }


### PR DESCRIPTION
Support in Home Assistant Core has been added in: <https://github.com/home-assistant/core/pull/43098>

```yaml
# Example configuration.yaml
automation:
  trigger:
    platform: tag
    tag_id:
      - A7-6B-90-5F
      - A7-6B-44-AD
```


```yaml
# Example configuration.yaml
automation:
  trigger:
    platform: tag
    tag_id: A7-6B-90-5F
    device_id:
      - 0e19cd3cf2b311ea88f469a7512c307d
      - d0609cb25f4a13922bb27d8f86e4c821
```

```yaml
# Example configuration.yaml
automation:
  trigger:
    platform: tag
    tag_id:
      - A7-6B-90-5F
      - A7-6B-44-AD
    device_id:
      - 0e19cd3cf2b311ea88f469a7512c307d
      - d0609cb25f4a13922bb27d8f86e4c821
```