### PR TITLE
Rename placeholder custom tag to input

### DIFF
--- a/src/language-service/src/haConfig/haYamlFile.ts
+++ b/src/language-service/src/haConfig/haYamlFile.ts
@@ -96,7 +96,7 @@ export class HomeAssistantYamlFile {
   private getCustomTags(): Schema.Tag[] {
     return [
       `env_Var`,
-      `placeholder`,
+      `input`,
       `secret`,
       `${Includetype[Includetype.include]}`,
       `${Includetype[Includetype.include_dir_list]}`,

--- a/src/language-service/src/haLanguageService.ts
+++ b/src/language-service/src/haLanguageService.ts
@@ -78,7 +78,7 @@ export class HomeAssistantLanguageService {
       }
     }
     validTags.push("!env_var scalar");
-    validTags.push("!placeholder scalar");
+    validTags.push("!input scalar");
     validTags.push("!secret scalar");
 
     return validTags;


### PR DESCRIPTION
On the Home Assistant Core dev, the new `!placeholder` is being renamed to `!input` to better match the use case.

This PR does the same on the extension.