### PR TITLE
Add support for the Uptime integration

### DIFF
--- a/src/language-service/src/schemas/integrations/core/sensor.ts
+++ b/src/language-service/src/schemas/integrations/core/sensor.ts
@@ -7,6 +7,7 @@ import { PlatformSchema } from "../platform";
 import { SensorPlatformSchema as TemplatePlatformSchema } from "./template";
 import { SensorPlatformSchema as MQTTPlatformSchema } from "./mqtt";
 import { SensorPlatformSchema as MQTTRoomPlatformSchema } from "./mqtt_room";
+import { SensorPlatformSchema as UptimePlatformSchema } from "./uptime";
 
 export type Domain = "sensor";
 export type Schema = Item[] | IncludeList;
@@ -17,7 +18,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!(mqtt|mqtt_room|template)$)\w+$
+   * @TJS-pattern ^(?!(mqtt|mqtt_room|template|uptime)$)\w+$
    */
   platform: string;
 }
@@ -26,4 +27,5 @@ type Item =
   | MQTTPlatformSchema
   | MQTTRoomPlatformSchema
   | TemplatePlatformSchema
+  | UptimePlatformSchema
   | OtherPlatform;

--- a/src/language-service/src/schemas/integrations/core/uptime.ts
+++ b/src/language-service/src/schemas/integrations/core/uptime.ts
@@ -1,0 +1,21 @@
+/**
+ * Uptime integration
+ * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/uptime/
+ */
+import { PlatformSchema } from "../platform";
+
+export type Domain = "uptime";
+
+export interface SensorPlatformSchema extends PlatformSchema {
+  /**
+   * The uptime sensor platform displays the time since the last Home Assistant restart.
+   * https://www.home-assistant.io/integrations/uptime
+   */
+  platform: "uptime";
+
+  /**
+   * Name to use in the frontend.
+   * https://www.home-assistant.io/integrations/uptime#name
+   */
+  name?: string;
+}

--- a/src/language-service/src/schemas/integrations/core/uptime.ts
+++ b/src/language-service/src/schemas/integrations/core/uptime.ts
@@ -2,6 +2,7 @@
  * Uptime integration
  * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/uptime/
  */
+import { Deprecated } from "../../types";
 import { PlatformSchema } from "../platform";
 
 export type Domain = "uptime";
@@ -18,4 +19,10 @@ export interface SensorPlatformSchema extends PlatformSchema {
    * https://www.home-assistant.io/integrations/uptime#name
    */
   name?: string;
+
+  /**
+   * DEPRECATED.
+   * This configuration option has been deprecated and can be removed from your configuration.
+   */
+  unit_of_measurement?: Deprecated;
 }


### PR DESCRIPTION
This PR adds support for the Uptime integration, which is a platform sensor.

Schema is based on the schema provided by the upcoming Home Assistant version.