### PR TITLE
Add the ability to reload knx integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,6 +233,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.knxReload",
+        "title": "Reload KNX",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -237,6 +237,7 @@ export async function activate(
       "rpi_gpio",
       "reload"
     ),
+    new CommandMappings("vscode-home-assistant.knxReload", "knx", "reload"),
     new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",


### PR DESCRIPTION
Add support for reloading the KNX integration.

The service `knx.reload` was added in <https://github.com/home-assistant/core/pull/42429>

