### PR TITLE
Add the ability to reload template sensors

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
       },
       {
         "command": "vscode-home-assistant.templateReload",
-        "title": "Reload Template Sensors",
+        "title": "Reload Template Entities",
         "category": "Home Assistant"
       },
       {

--- a/package.json
+++ b/package.json
@@ -238,6 +238,11 @@
         "category": "Home Assistant"
       },
       {
+        "command": "vscode-home-assistant.templateReload",
+        "title": "Reload Template Sensors",
+        "category": "Home Assistant"
+      },
+      {
         "command": "vscode-home-assistant.hassioAddonRestartGitPull",
         "title": "Restart 'Git Pull' Add-on",
         "category": "Home Assistant"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -238,7 +238,11 @@ export async function activate(
       "reload"
     ),
     new CommandMappings("vscode-home-assistant.knxReload", "knx", "reload"),
-    new CommandMappings("vscode-home-assistant.templateReload", "template", "reload"),
+    new CommandMappings(
+      "vscode-home-assistant.templateReload",
+      "template",
+      "reload"
+    ),
     new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
@@ -249,7 +253,7 @@ export async function activate(
       "vscode-home-assistant.hassioHostReboot",
       "hassio",
       "host_reboot"
-    ),    
+    ),
   ];
 
   commandMappings.forEach((mapping) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -238,6 +238,7 @@ export async function activate(
       "reload"
     ),
     new CommandMappings("vscode-home-assistant.knxReload", "knx", "reload"),
+    new CommandMappings("vscode-home-assistant.templateReload", "template", "reload"),
     new CommandMappings(
       "vscode-home-assistant.hassioAddonRestartGitPull",
       "hassio",
@@ -248,8 +249,7 @@ export async function activate(
       "vscode-home-assistant.hassioHostReboot",
       "hassio",
       "host_reboot"
-    ),
-    new CommandMappings("vscode-home-assistant.templateReload", "template", "reload"),
+    ),    
   ];
 
   commandMappings.forEach((mapping) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -249,6 +249,7 @@ export async function activate(
       "hassio",
       "host_reboot"
     ),
+    new CommandMappings("vscode-home-assistant.templateReload", "template", "reload"),
   ];
 
   commandMappings.forEach((mapping) => {


### PR DESCRIPTION
Add support for reloading Template Sensors.

The service template.reload was added in home-assistant/core#39075 