### PR TITLE
Fix MQTT tilt_command_topic type

### DIFF
--- a/src/language-service/src/schemas/integrations/core/mqtt.ts
+++ b/src/language-service/src/schemas/integrations/core/mqtt.ts
@@ -1299,7 +1299,7 @@ export interface CoverPlatformSchema extends PlatformSchema {
    * The MQTT topic to publish commands to control the cover tilt.
    * https://www.home-assistant.io/integrations/cover.mqtt/#tilt_command_topic
    */
-  tilt_command_topic?: Integer;
+  tilt_command_topic?: string;
 
   /**
    * Flag that determines if open/close are flipped; higher values toward closed and lower values toward open.


### PR DESCRIPTION
Fixes the MQTT `tilt_command_topic` option, it was an integration but should be a string.

fixes #929