### PR TITLE
Allow use of number helpers on numeric state triggers

### DIFF
--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -191,13 +191,13 @@ interface NumericStateTrigger {
    * Fire this trigger if the numeric state of the monitored entity (or entities) is changing from above to below the given threshold.
    * https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger
    */
-  below?: string | number;
+  below?: number | InputNumberEntity;
 
   /**
    * Fire this trigger if the numeric state of the monitored entity (or entities) is changing from below to above the given threshold.
    * https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger
    */
-  above?: string | number;
+  above?: number | InputNumberEntity;
 
   /**
    * An optional value template to use as the numeric state value.

--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -6,6 +6,7 @@ import {
   Data,
   Entities,
   InputDatetimeEntities,
+  InputNumberEntity,
   Template,
   TimePeriod,
   ZoneEntity,

--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -191,13 +191,13 @@ interface NumericStateTrigger {
    * Fire this trigger if the numeric state of the monitored entity (or entities) is changing from above to below the given threshold.
    * https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger
    */
-  below?: number;
+  below?: string | number;
 
   /**
    * Fire this trigger if the numeric state of the monitored entity (or entities) is changing from below to above the given threshold.
    * https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger
    */
-  above?: number;
+  above?: string | number;
 
   /**
    * An optional value template to use as the numeric state value.


### PR DESCRIPTION
This update is to allow for input_numbers to be used in the above and below options of the numeric state trigger as per recent change to this trigger: https://github.com/home-assistant/core/pull/45091