### PR TITLE
Fix Lovelace card compatibility with Entity Filter

### DIFF
--- a/src/language-service/src/schemas/lovelace/cards/calendar.ts
+++ b/src/language-service/src/schemas/lovelace/cards/calendar.ts
@@ -18,7 +18,7 @@ export interface Schema {
    * A list of calendar entities that will be displayed in the card.
    * https://www.home-assistant.io/lovelace/calendar/#entities
    */
-  entities: Entity[];
+  entities?: Entity[];
 
   /**
    * The view that will show first when the card is loaded onto the page.

--- a/src/language-service/src/schemas/lovelace/cards/entities.ts
+++ b/src/language-service/src/schemas/lovelace/cards/entities.ts
@@ -22,7 +22,7 @@ export interface Schema {
    * A list of entity IDs or entity (row) objects.
    * https://www.home-assistant.io/lovelace/entities/#entities
    */
-  entities: Entity[];
+  entities?: Entity[];
 
   /**
    * Header widget to render.

--- a/src/language-service/src/schemas/lovelace/cards/glance.ts
+++ b/src/language-service/src/schemas/lovelace/cards/glance.ts
@@ -29,7 +29,7 @@ export interface Schema {
    * A list of entity IDs or entity objects.
    * https://www.home-assistant.io/lovelace/glance/#entities
    */
-  entities: Entity[];
+  entities?: Entity[];
 
   /**
    * Show entity icon.

--- a/src/language-service/src/schemas/lovelace/cards/logbook.ts
+++ b/src/language-service/src/schemas/lovelace/cards/logbook.ts
@@ -18,7 +18,7 @@ export interface Schema {
    * The entities that will show in the card.
    * https://www.home-assistant.io/lovelace/logbook/#entities
    */
-  entities: Entity[];
+  entities?: Entity[];
 
   /**
    * Number of hours in the past to track.

--- a/src/language-service/src/schemas/lovelace/cards/map.ts
+++ b/src/language-service/src/schemas/lovelace/cards/map.ts
@@ -26,7 +26,7 @@ export interface Schema {
    * List of entity IDs. Either this or the geo_location_sources configuration option is required.
    * https://www.home-assistant.io/lovelace/map/#entities
    */
-  entities: Entity | Entity[];
+  entities?: Entity | Entity[];
 
   /**
    * List of geolocation sources. All current entities with that source will be displayed on the map. See Geolocation platform for valid sources. Set to all to use all available sources. Either this or the entities configuration option is required.


### PR DESCRIPTION
When the `entity-filter` card is used, the cards that are used underneath is, may omit the `entities` property.

This PR adjusts all Lovelace cards that support multiple entities, to have that property optional (so they become compatible with `entity-filter`.

```yaml
type: entity-filter
entities:
  - device_tracker.demo_paulus
  - device_tracker.demo_anne_therese
  - device_tracker.demo_home_boy
state_filter:
  - operator: "!="
    value: home
  - operator: "!="
    value: work
card:
  type: glance
  title: Who's Running Errands
```

fixes #968