### PR TITLE
Add homeassistant.temperature_unit

### DIFF
--- a/src/language-service/src/schemas/integrations/core/homeassistant.ts
+++ b/src/language-service/src/schemas/integrations/core/homeassistant.ts
@@ -7,6 +7,7 @@ import {
   Integer,
   TimeZone,
   UnitSystem,
+  TemperatureUnit,
 } from "../../types";
 
 export type Domain = "group";
@@ -117,6 +118,13 @@ export interface Schema {
    * https://www.home-assistant.io/docs/configuration/basic/#unit_system
    */
   unit_system?: UnitSystem;
+
+  /**
+   * Override temperature unit set by unit_system.
+   * "C" for Celsius, "F" for Fahrenheit.
+   * https://www.home-assistant.io/docs/configuration/basic/#temperature_unit
+   */
+  temperature_unit?: TemperatureUnit;
 
   /**
    * DEPRECATED as of Home Assistant 0.113.0.

--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -976,3 +976,4 @@ export type TimeZone =
   | "Zulu";
 
 export type UnitSystem = "metric" | "imperial";
+export type TemperatureUnit = "C" | "F";


### PR DESCRIPTION
First of all, thank you for this awesome extension! Took me way to long to find it.

After installing it, I noticed that `temperature_unit` in the `homeassistant` domain isn't in the schema.
The documentation for it can be found here: https://home-assistant.io/docs/configuration/basic/#temperature_unit