### PR TITLE
Add setting to disable automatic YAML file association

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
           "vscode-home-assistant.ignoreCertificates": {
             "type": "boolean",
             "description": "Enable insecure transport. Check this if you want to connect over an insecure HTTPS transport with a invalid certificate!"
+          },
+          "vscode-home-assistant.disableAutomaticFileAssociation": {
+            "type": "boolean",
+            "description": "Disables the automatic file association creation in .vscode/settings.json that associates YAML files with the Home Assistant file language.",
+            "default": false
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -331,7 +331,10 @@ export async function activate(
     .get("files.associations");
   if (
     !fileAssociations["*.yaml"] &&
-    Object.values(fileAssociations).indexOf("home-assistant") === -1
+    Object.values(fileAssociations).indexOf("home-assistant") === -1 &&
+    vscode.workspace
+      .getConfiguration()
+      .get("vscode-home-assistant.disableAutomaticFileAssociation", false) === false
   ) {
     await vscode.workspace
       .getConfiguration()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -334,7 +334,8 @@ export async function activate(
     Object.values(fileAssociations).indexOf("home-assistant") === -1 &&
     vscode.workspace
       .getConfiguration()
-      .get("vscode-home-assistant.disableAutomaticFileAssociation", false) === false
+      .get("vscode-home-assistant.disableAutomaticFileAssociation", false) ===
+      false
   ) {
     await vscode.workspace
       .getConfiguration()

--- a/src/language-service/src/configuration.ts
+++ b/src/language-service/src/configuration.ts
@@ -13,6 +13,7 @@ export interface HomeAssistantConfiguration {
   longLivedAccessToken?: string;
   hostUrl?: string;
   ignoreCertificates: boolean;
+  disableAutomaticFileAssociation: boolean;
 }
 
 export class ConfigurationService implements IConfigurationService {
@@ -23,6 +24,8 @@ export class ConfigurationService implements IConfigurationService {
   public url?: string;
 
   public ignoreCertificates = false;
+
+  public disableAutomaticFileAssociation = false;
 
   constructor() {
     this.setConfigViaEnvironmentVariables();
@@ -41,6 +44,7 @@ export class ConfigurationService implements IConfigurationService {
       this.url = this.getUri(incoming.hostUrl);
     }
     this.ignoreCertificates = !!incoming.ignoreCertificates;
+    this.disableAutomaticFileAssociation = !!incoming.disableAutomaticFileAssociation;
 
     this.setConfigViaEnvironmentVariables();
 


### PR DESCRIPTION
Should resolve #961 without changing existing default behavior.

Changes:
* Add boolean setting `vscode-home-assistant.disableAutomaticFileAssociation` (defaults to `false`).
* Update  `HomeAssistantConfiguration` interface and `ConfigurationService` class with the `disableAutomaticFileAssociation` property (not currently used, but keeping LS configuration in sync with available configuration options).
* Update to `fileAssociations` section of `extension.ts` with an additional conditional check in the `if` statement to read in the new configuration setting.