### PR TITLE
Target now supports templates

### DIFF
--- a/src/language-service/src/schemas/integrations/actions.ts
+++ b/src/language-service/src/schemas/integrations/actions.ts
@@ -202,7 +202,7 @@ export interface ServiceAction {
    * The entity (or entities) to execute this service call on.
    * https://www.home-assistant.io/docs/scripts/service-calls
    */
-  entity_id?: Entities | "all" | "none" | null;
+  entity_id?: Entities | "all" | "none" | null | Template;
 
   /**
    * Defines the target (area(s), device(s) and entitie(s)) to execute this service call on.
@@ -213,13 +213,13 @@ export interface ServiceAction {
      * The entity (or entities) to execute this service call on.
      * https://www.home-assistant.io/docs/scripts/service-calls
      */
-    entity_id?: Entities | "all" | "none" | null;
+    entity_id?: Entities | "all" | "none" | null | Template;
 
     /**
      * The device (or devices) to execute this service call on.
      * https://www.home-assistant.io/docs/scripts/service-calls
      */
-    device_id?: string | string[] | "none";
+    device_id?: string | string[] | "none" | Template;
 
     /**
      * The area (or areas) to execute this service call on.


### PR DESCRIPTION
As of Home Assistant 2021.3, targets support templates.
This PR corrects that in the extension schema.

```yaml
- service: light.turn_on
  target:
    entity_id: "{{ my_variable }}"
```