### PR TITLE
Support value_template in MQTT trigger

### DIFF
--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -173,6 +173,12 @@ interface MqttTrigger {
    * https://www.home-assistant.io/docs/automation/trigger/#mqtt-trigger
    */
   topic: string;
+
+  /**
+   * Value template allows, for example, picking out a JSON key from the incoming MQTT message.
+   * https://www.home-assistant.io/docs/automation/trigger/#mqtt-trigger
+   */
+  value_template?: Template;
 }
 
 interface NumericStateTrigger {


### PR DESCRIPTION
Home Assistant Core 2021.3 added support for having a `value_template` in an MQTT trigger.

```yaml
automation:
  trigger:
    platform: mqtt
    topic: "living_room/switch/ac"
    payload: "on"
    value_template: "{{ value_json.state }}"
```

Upstream PR: <https://github.com/home-assistant/core/pull/46891>