### PR TITLE
Add support for weather templates

### DIFF
--- a/src/language-service/src/schemas/configuration.ts
+++ b/src/language-service/src/schemas/configuration.ts
@@ -166,6 +166,12 @@ export interface InternalIntegrations {
    * https://www.home-assistant.io/integrations/vacuum
    */
   vacuum?: integrations.Core.Vacuum.Schema | IncludeList;
+
+  /**
+   * The weather platforms gather meteorological information from web services and display the conditions and other details about the weather at the given location.
+   * https://www.home-assistant.io/integrations/weather
+   */
+  weather?: integrations.Core.Weather.Schema | IncludeList;
 }
 
 /**

--- a/src/language-service/src/schemas/integrations/core/index.d.ts
+++ b/src/language-service/src/schemas/integrations/core/index.d.ts
@@ -26,3 +26,4 @@ export * as Script from "./script";
 export * as Sensor from "./sensor";
 export * as Switch from "./switch";
 export * as Vacuum from "./vacuum";
+export * as Weather from "./weather";

--- a/src/language-service/src/schemas/integrations/core/template.ts
+++ b/src/language-service/src/schemas/integrations/core/template.ts
@@ -195,6 +195,56 @@ export interface VacuumPlatformSchema extends PlatformSchema {
   };
 }
 
+export interface WeatherPlatformSchema extends PlatformSchema {
+  /**
+   * The template integrations creates weather provider that combines integrations and an existing weather provider into a fused weather provider.
+   * https://www.home-assistant.io/integrations/weather.template
+   */
+  platform: "template";
+
+  /**
+   * Defines templates for the current weather condition.
+   * https://www.home-assistant.io/integrations/weather.template#condition_template
+   */
+  condition_template: Template;
+
+  /**
+   * Defines templates for the daily forcast data.
+   * https://www.home-assistant.io/integrations/weather.template#forecast_template
+   */
+  forecast_template?: Template;
+
+  /**
+   * Defines templates for the current humidity.
+   * https://www.home-assistant.io/integrations/weather.template#humidity_template
+   */
+  humidity_template: Template;
+
+  /**
+   * Name to use in the frontend.
+   * https://www.home-assistant.io/integrations/weather.template#name
+   */
+  name: string;
+
+  /**
+   * Defines templates for the current air pressure.
+   * https://www.home-assistant.io/integrations/weather.template#pressure_template
+   */
+  pressure_template?: Template;
+
+  /**
+   * Defines templates for the current temperature.
+   * https://www.home-assistant.io/integrations/weather.template#temperature_template
+   */
+  temperature_template: Template;
+
+  /**
+   * Defines templates for the current wind speed.
+   * https://www.home-assistant.io/integrations/weather.template#wind_speed_template
+   */
+  wind_speed_template?: Template;
+}
+
 interface AlarmControlPanelItem {
   /**
    * Defines an action to run when the alarm is armed to away mode.

--- a/src/language-service/src/schemas/integrations/core/weather.ts
+++ b/src/language-service/src/schemas/integrations/core/weather.ts
@@ -1,0 +1,23 @@
+/**
+ * Weather integration
+ * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/weather/__init__.py
+ */
+import { IncludeList } from "../../types";
+import { PlatformSchema } from "../platform";
+import { WeatherPlatformSchema as TemplatePlatformSchema } from "./template";
+
+export type Domain = "weather";
+export type Schema = Item[] | IncludeList;
+export type File = Item | Item[];
+
+/**
+ * @TJS-additionalProperties true
+ */
+interface OtherPlatform extends PlatformSchema {
+  /**
+   * @TJS-pattern ^(?!(template)$)\w+$
+   */
+  platform: string;
+}
+
+type Item = TemplatePlatformSchema | OtherPlatform;

--- a/src/language-service/src/schemas/mappings.json
+++ b/src/language-service/src/schemas/mappings.json
@@ -147,6 +147,13 @@
     "fromType": "File"
   },
   {
+    "key": "integration-weather",
+    "path": "configuration.yaml/weather",
+    "file": "integration-weather.json",
+    "tsFile": "integrations/core/weather.ts",
+    "fromType": "File"
+  },
+  {
     "key": "lovelace-dashboard",
     "path": "ui-lovelace.yaml",
     "file": "lovelace-dashboard.json",


### PR DESCRIPTION
Add support for the weather templates introduced in Home Assistant 2021.3.0.

Docs: <https://www.home-assistant.io/integrations/weather.template>


This PR also adds the initial framework defining weather platforms (as it wasn't there before).