### PR TITLE
Explicitly build a full schema in CI

### DIFF
--- a/.github/workflows/github-actions-language-service.yml
+++ b/.github/workflows/github-actions-language-service.yml
@@ -32,6 +32,10 @@ jobs:
         working-directory: src/language-service
         run: npm run lint
 
+      - name: 🚀 Build Schema
+        working-directory: src/language-service
+        run: npm run schema
+
       - name: 🚀 Run Compile
         working-directory: src/language-service
         run: npm run compile

--- a/.github/workflows/github-actions-vscode-extension.yml
+++ b/.github/workflows/github-actions-vscode-extension.yml
@@ -22,6 +22,9 @@ jobs:
       - name: 🚀 Run Linter
         run: npm run lint
 
+      - name: 🚀 Build Schema
+        run: npm run schema
+
       - name: 🚀 Run Compile
         run: npm run compile
 


### PR DESCRIPTION
Somehow our JSON Schema ended up being not completely correct in the latest stable release.

I'm not sure why yet, but I did notice we ran a "quick" schema build in the CI (including the release builds). This variant takes a shortcut... so, this PR makes sure we run a full schema build.

Possibly improves #1058 