### PR TITLE
Make severity optional in gauge card for Lovelace schema

### DIFF
--- a/src/language-service/src/schemas/lovelace/cards/gauge.ts
+++ b/src/language-service/src/schemas/lovelace/cards/gauge.ts
@@ -43,7 +43,7 @@ export interface Schema {
    * Allows setting of colors for different numbers.
    * https://www.home-assistant.io/lovelace/gauge/#severity
    */
-  severity: Severity;
+  severity?: Severity;
 
   /**
    * Set to any theme within themes.yaml.


### PR DESCRIPTION
According to https://www.home-assistant.io/lovelace/gauge/, the severity property is optional.