### PR TITLE
Added state_stopped attribute to a MQTT Cover

### DIFF
--- a/src/language-service/src/schemas/integrations/core/mqtt.ts
+++ b/src/language-service/src/schemas/integrations/core/mqtt.ts
@@ -1284,6 +1284,12 @@ export interface CoverPlatformSchema extends PlatformSchema {
   state_opening?: string;
 
   /**
+   * The payload that represents the stopped state (for covers that do not report open/closed state).
+   * https://www.home-assistant.io/integrations/cover.mqtt/#state_stopped
+   */
+  state_stopped?: string;
+
+  /**
    * The MQTT topic subscribed to receive cover state messages. Use only if not using position_topic. State topic can only read open/close state.
    * https://www.home-assistant.io/integrations/cover.mqtt/#state_topic
    */


### PR DESCRIPTION
At the moment, the plugin reports that "state_stopped" is an invalid attribute, while it is not.

<img width="474" alt="image" src="https://user-images.githubusercontent.com/3165145/112115576-a34ee780-8bb9-11eb-9b7e-c4bad00c30f6.png">

https://www.home-assistant.io/integrations/cover.mqtt/#state_stopped