### PR TITLE
Add support for Blueprints

### DIFF
--- a/src/language-service/src/haConfig/haConfig.ts
+++ b/src/language-service/src/haConfig/haConfig.ts
@@ -101,8 +101,13 @@ export class HomeAssistantConfiguration {
   private getRootFiles = (): string[] => {
     const filesInRoot = this.fileAccessor.getFilesInFolder("");
     const ourFiles = ["configuration.yaml", "ui-lovelace.yaml"];
+    const ourFolders = ["blueprints/automation/"];
 
-    const files = ourFiles.filter((f) => filesInRoot.some((y) => y === f));
+    const rootFiles = ourFiles.filter((f) => filesInRoot.some((y) => y === f));
+    const subfolderFiles = filesInRoot.filter((f) =>
+      ourFolders.some((y) => f.startsWith(y))
+    );
+    const files = [...rootFiles, ...subfolderFiles];
 
     if (files.length === 0) {
       const areOurFilesSomehwere = filesInRoot.filter((f) =>

--- a/src/language-service/src/schemas/configuration.ts
+++ b/src/language-service/src/schemas/configuration.ts
@@ -46,7 +46,7 @@ export interface InternalIntegrations {
    * Blueprints provide predefined templates for e.g., automations.
    * https://www.home-assistant.io/integrations/blueprint
    */
-  blueprint?: null;
+  blueprint?: integrations.Core.Blueprint.Schema;
 
   /**
    * The camera integration allows you to use IP cameras with Home Assistant.

--- a/src/language-service/src/schemas/integrations/core/blueprint.ts
+++ b/src/language-service/src/schemas/integrations/core/blueprint.ts
@@ -1,26 +1,112 @@
 /**
- * Automation integration
- * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/automation/__init__.py
+ * Blueprint integration
+ * Source:
+ * - https://github.com/home-assistant/core/blob/dev/homeassistant/components/blueprint/__init__.py
+ * - https://github.com/home-assistant/core/blob/dev/homeassistant/components/blueprint/models.py
+ * - https://github.com/home-assistant/core/blob/dev/homeassistant/components/blueprint/schemas.py
  */
 import { Data, Deprecated, IncludeList } from "../../types";
+import { Selector } from "../selectors";
+import { Mode } from "./automation";
 import { Action } from "../actions";
 import { Condition } from "../conditions";
 import { Trigger } from "../triggers";
 
-export type Domain = "automation";
-export type Schema = Item[] | IncludeList;
-export type File = Item | Item[];
+export type Domain = "blueprint";
+export type Schema = null;
 
-export type Mode = "single" | "parallel" | "queued" | "restart";
-type Item = AutomationItem | BlueprintItem;
+export interface AutomationBlueprintFile {
+  /**
+   * The blueprint schema.
+   * https://www.home-assistant.io/docs/blueprint/schema/#the-blueprint-schema
+   */
+  blueprint: AutomationBlueprint;
+}
 
-interface BaseItem {
+// export interface AutomationBlueprint extends AutomationItem, Blueprint {}
+
+interface Blueprint {
+  /**
+   * The description of the blueprint. While optional, this field is highly recommended. The description can include Markdown.
+   * https://www.home-assistant.io/docs/blueprint/schema/#description
+   */
+  description?: string;
+
+  /**
+   * The domain name this blueprint provides a blueprint for.
+   * https://www.home-assistant.io/docs/blueprint/schema/#domain
+   */
+  domain: string;
+
+  /**
+   * Home Assistant requirements for this Blueprint.
+   */
+  homeassistant?: {
+    /**
+     * The minimal version number of Home Assistant Core that is needed for this Blueprint.
+     */
+    min_version?: string;
+  };
+
+  /**
+   * These are the input fields that the consumer of your blueprint can provide using YAML definition, or via a configuration form in the UI.
+   * https://www.home-assistant.io/docs/blueprint/schema/#input
+   */
+  input?: {
+    [key: string]: BlueprintInputSchema;
+  };
+
+  /**
+   * The name of the blueprint. Keep this short and descriptive.
+   * https://www.home-assistant.io/docs/blueprint/schema/#name
+   */
+  name: string;
+
+  /**
+   * The URL to the online location where this Blueprint was imported from. Generally there is no need to add this, in the future this might be used for updating Blueprints.
+   */
+  source_url?: string;
+}
+
+interface BlueprintInputSchema {
+  /**
+   * The name of the input field.
+   * https://www.home-assistant.io/docs/blueprint/schema/#name
+   */
+  name?: string;
+
+  /**
+   * A short description of the input field. Keep this short and descriptive.
+   * https://www.home-assistant.io/docs/blueprint/schema/#description
+   */
+  description?: string;
+
+  /**
+   * The default value of this input, in case the input is not provided by the user of this blueprint.
+   * https://www.home-assistant.io/docs/blueprint/schema/#default
+   */
+  default?: string;
+
+  /**
+   * The default value of this input, in case the input is not provided by the user of this blueprint.
+   * https://www.home-assistant.io/docs/blueprint/schema/#default
+   */
+  selector?: Selector;
+}
+
+export interface AutomationBlueprint extends Blueprint {
   /**
    * A unique identifier for this automation.
    * Do not use the same twice, ever!
    * https://www.home-assistant.io/docs/automation/
    */
   id?: string;
+
+  /**
+   * The domain name this blueprint provides a blueprint for.
+   * https://www.home-assistant.io/docs/blueprint/schema/#domain
+   */
+  domain: "automation";
 
   /**
    * Alias will be used to generate an entity_id from.
@@ -88,9 +174,7 @@ interface BaseItem {
    * https://www.home-assistant.io/docs/automation/#automation-basics
    */
   condition?: Condition | Condition[] | IncludeList;
-}
 
-interface AutomationItem extends BaseItem {
   /**
    * Triggers describe events that should trigger the automation rule.
    * https://www.home-assistant.io/docs/automation/#automation-basics
@@ -102,23 +186,4 @@ interface AutomationItem extends BaseItem {
    * https://www.home-assistant.io/docs/automation/#automation-basics
    */
   action: Action | Action[] | IncludeList;
-}
-
-interface BlueprintItem extends BaseItem {
-  use_blueprint: {
-    path: string;
-    input: { [key: string]: any };
-  };
-
-  /**
-   * Triggers describe events that should trigger the automation rule.
-   * https://www.home-assistant.io/docs/automation/#automation-basics
-   */
-  trigger?: Trigger | Trigger[] | IncludeList;
-
-  /**
-   * The action(s) which will be performed when a rule is triggered and all conditions are met. For example, it can turn a light on, set the temperature on your thermostat or activate a scene.
-   * https://www.home-assistant.io/docs/automation/#automation-basics
-   */
-  action?: Action | Action[] | IncludeList;
 }

--- a/src/language-service/src/schemas/integrations/core/index.d.ts
+++ b/src/language-service/src/schemas/integrations/core/index.d.ts
@@ -1,6 +1,7 @@
 export * as AlarmControlPanel from "./alarm_control_panel";
 export * as Automation from "./automation";
 export * as BinarySensor from "./binary_sensor";
+export * as Blueprint from "./blueprint";
 export * as Camera from "./camera";
 export * as Climate from "./climate";
 export * as Cloud from "./cloud";

--- a/src/language-service/src/schemas/integrations/selectors.ts
+++ b/src/language-service/src/schemas/integrations/selectors.ts
@@ -1,0 +1,306 @@
+/**
+ * Selectors
+ * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/selector.py
+ */
+import { Domain, DeviceClasses } from "../types";
+
+export type Selector =
+  | ActionSelector
+  | AddonSelector
+  | AreaSelector
+  | BooleanSelector
+  | DeviceSelector
+  | EntitySelector
+  | NumberSelector
+  | ObjectSelector
+  | SelectSelector
+  | TargetSelector
+  | TextSelector
+  | TimeSelector;
+
+export interface ActionSelector {
+  /**
+   * The action selector allows the user to input one or more sequences of actions.
+   * https://www.home-assistant.io/docs/blueprint/selectors/#action-selector
+   */
+  action: null;
+}
+
+export interface AddonSelector {
+  /**
+   * The add-on selector allows the user to input an add-on slug. On the user interface, it will list all installed add-ons and use the slug of the selected add-on.
+   * https://www.home-assistant.io/docs/blueprint/selectors/#add-on-selector
+   */
+  addon: null;
+}
+
+export interface AreaSelector {
+  /**
+   * The area selector shows an area finder that can pick a single area. The value of the input will be the area ID of the user-selected area.
+   * https://www.home-assistant.io/docs/blueprint/selectors/#area-selector
+   */
+  area: {
+    /**
+     * When device options are provided, the list of areas is filtered by areas that at least provide one device that matches the given conditions.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#area-selector
+     */
+    device?: {
+      /**
+       * Can be set to an integration domain. Limits the list of areas that provide devices by the set integration domain.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#area-selector
+       */
+      integration?: string;
+
+      /**
+       * When set, it limits the list of areas that provide devices by the set manufacturer name.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#area-selector
+       */
+      manufacturer?: string;
+
+      /**
+       * When set, it limits the list of areas that provide devices that have the set model.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#area-selector
+       */
+      model?: string;
+    };
+
+    /**
+     * When entity options are provided, the list of areas is filtered by areas that at least provide one entity that matches the given conditions.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#area-selector
+     */
+    entity?: {
+      /**
+       * Limits the list of areas that provide entities of a certain domain, for example, light or binary_sensor.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#area-selector
+       */
+      domain?: Domain;
+
+      /**
+       * Limits the list of areas to areas that have entities with a certain device class, for example, motion or window.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#area-selector
+       */
+      device_class?: DeviceClasses;
+
+      /**
+       * Can be set to an integration domain. Limits the list of areas that provide entities by the set integration domain.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#area-selector
+       */
+      integration?: string;
+    };
+  } | null;
+}
+
+export interface BooleanSelector {
+  /**
+   * The boolean selector shows a toggle that allows the user to turn on or off the selected option.
+   * https://www.home-assistant.io/docs/blueprint/selectors/#boolean-selector
+   */
+  boolean: null;
+}
+
+export interface DeviceSelector {
+  /**
+   * The device selector shows a device finder that can pick a single device.
+   * https://www.home-assistant.io/docs/blueprint/selectors/#device-selector
+   */
+  device: {
+    /**
+     * When entity options are provided, the list of devices is filtered by devices that at least provide one entity that matches the given conditions.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#device-selector
+     */
+    entity?: {
+      /**
+       * Can be set to an integration domain. Limits the list of devices that provide entities by the set integration domain.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#device-selector
+       */
+      integration?: string;
+      /**
+       * Limits the list of devices that provide entities of a certain domain.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#device-selector
+       */
+      domain?: Domain;
+      /**
+       * Limits the list of entities to entities that have a certain device class.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#device-selector
+       */
+      device_class?: DeviceClasses;
+    };
+    /**
+     * Can be set to an integration domain. Limits the list of devices to devices provided by the set integration domain.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#device-selector
+     */
+    integration?: string;
+    /**
+     * When set, it limits the list of devices to devices provided by the set manufacturer name.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#device-selector
+     */
+    manufacturer?: string;
+    /**
+     * When set, it limits the list of devices to devices that have the set model.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#device-selector
+     */
+    model?: string;
+  } | null;
+}
+
+export interface EntitySelector {
+  /**
+   * The entity selector shows an entity finder that can pick a single entity.
+   * https://www.home-assistant.io/docs/blueprint/selectors/#entity-selector
+   */
+  entity: {
+    /**
+     * Can be set to an integration domain. Limits the list of devices that provide entities by the set integration domain.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#entity-selector
+     */
+    integration?: string;
+    /**
+     * Limits the list of devices that provide entities of a certain domain.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#entity-selector
+     */
+    domain?: Domain;
+    /**
+     * Limits the list of entities to entities that have a certain device class.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#entity-selector
+     */
+    device_class?: DeviceClasses;
+  } | null;
+}
+
+export interface NumberSelector {
+  /**
+   * The number selector shows either a number input or a slider input, that allows the user to specify a numeric value.
+   * https://www.home-assistant.io/docs/blueprint/selectors/#number-selector
+   */
+  number: {
+    /**
+     * The maximum user-settable number value.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#number-selector
+     */
+    max: number;
+
+    /**
+     * The minimal user-settable number value.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#number-selector
+     */
+    min: number;
+
+    /**
+     * This can be either box or slider mode.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#number-selector
+     */
+    mode?: "box" | "slider";
+
+    /**
+     * The step value of the number value.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#number-selector
+     */
+    step?: number;
+
+    /**
+     * Unit of measurement in which the number value is expressed in.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#number-selector
+     */
+    unit_of_measurement?: string;
+  };
+}
+
+export interface ObjectSelector {
+  /**
+   * The object selector can be used to input arbitrary data in YAML form. This is useful for e.g. lists and dictionaries like service data.
+   * https://www.home-assistant.io/docs/blueprint/selectors/#object-selector
+   */
+  object: null;
+}
+
+export interface SelectSelector {
+  /**
+   * The select selector shows a list of available options from which the user can choose.
+   * https://www.home-assistant.io/docs/blueprint/selectors/#select-selector
+   */
+  select: {
+    /**
+     * List of options that the user can choose from.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#select-selector
+     */
+    options: [string];
+  };
+}
+
+export interface TargetSelector {
+  /**
+   * The target selector is a rather special selector, allowing the user to select targeted entities, devices or areas for service calls.
+   * https://www.home-assistant.io/docs/blueprint/selectors/#target-selector
+   */
+  target: {
+    /**
+     * When device options are provided, the targets are limited by devices that at least match the given conditions.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#target-selector
+     */
+    device?: {
+      /**
+       * Can be set to an integration domain. Limits the device targets that are provided devices by the set integration domain.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#target-selector
+       */
+      integration?: string;
+
+      /**
+       * When set, it limits the targets to devices provided by the set manufacturer name.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#target-selector
+       */
+      manufacturer?: string;
+
+      /**
+       * When set, it limits the targets to devices by the set model.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#target-selector
+       */
+      model?: string;
+    };
+
+    /**
+     * When entity options are provided, the targets are limited by entities that at least match the given conditions.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#target-selector
+     */
+    entity?: {
+      /**
+       * Limits the targets to entities of a certain domain, for example, light or binary_sensor.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#target-selector
+       */
+      domain?: Domain;
+
+      /**
+       * Limits the targets to entities with a certain device class, for example, motion or window.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#target-selector
+       */
+      device_class?: DeviceClasses;
+
+      /**
+       * Can be set to an integration domain. Limits targets to entities provided by the set integration domain.
+       * https://www.home-assistant.io/docs/blueprint/selectors/#target-selector
+       */
+      integration?: string;
+    };
+  } | null;
+}
+
+export interface TextSelector {
+  /**
+   * The text selector can be used to input a text string.
+   * https://www.home-assistant.io/docs/blueprint/selectors/#text-selector
+   */
+  text: {
+    /**
+     * Set to true to display the input as a multi-line text box on the user interface.
+     * https://www.home-assistant.io/docs/blueprint/selectors/#text-selector
+     */
+    multiline?: boolean;
+  } | null;
+}
+
+export interface TimeSelector {
+  /**
+   * The time selector shows a time input that allows the user to specify a time of the day.
+   * https://www.home-assistant.io/docs/blueprint/selectors/#time-selector
+   */
+  time: null;
+}

--- a/src/language-service/src/schemas/mappings.json
+++ b/src/language-service/src/schemas/mappings.json
@@ -173,5 +173,12 @@
     "file": "lovelace-cards.json",
     "tsFile": "lovelace/types.ts",
     "fromType": "CardsFile"
+  },
+  {
+    "key": "blueprint-automation",
+    "path": "blueprints/automation",
+    "file": "blueprint-automation.json",
+    "tsFile": "integrations/core/blueprint.ts",
+    "fromType": "AutomationBlueprintFile"
   }
 ]

--- a/src/language-service/src/schemas/schemaService.ts
+++ b/src/language-service/src/schemas/schemaService.ts
@@ -35,17 +35,21 @@ export class SchemaServiceForIncludes {
         "cards"
       );
 
+      if (sourceFileMappingPath.startsWith("blueprints/automation/")) {
+        sourceFileMappingPath = "blueprints/automation";
+      }
+
       const relatedPathToSchemaMapping = this.mappings.find(
         (x) => x.path === sourceFileMappingPath
       );
       if (relatedPathToSchemaMapping) {
         const id = `http://schemas.home-assistant.io/${relatedPathToSchemaMapping.key}`;
-        let relativePath = path.relative(
+        let absolutePath = path.resolve(
           process.cwd(),
           haFiles[sourceFile].filename
         );
-        relativePath = relativePath.replace("\\", "/");
-        const fileass = `**/${encodeURI(relativePath)}`;
+        absolutePath = absolutePath.replace("\\", "/");
+        const fileass = encodeURI(absolutePath);
         let resultEntry = results.find((x) => x.uri === id);
 
         if (!resultEntry) {


### PR DESCRIPTION
This PR adds support for Blueprints to the extension. It implements the full schema, including all the new selectors.

For this change, I had to adjust how schema assignment works, as the blueprint doesn't have to be referenced in the configuration root. However, the folders where the blueprints are fixed, thus those folder locations are now also taken into consideration.