### PR TITLE
Add auto-completion support for Domains

### DIFF
--- a/src/language-service/src/completionHelpers/domains.ts
+++ b/src/language-service/src/completionHelpers/domains.ts
@@ -1,0 +1,76 @@
+import { MarkedString } from "vscode-languageserver-protocol";
+import {
+  JSONWorkerContribution,
+  JSONPath,
+  CompletionsCollector,
+} from "vscode-json-languageservice";
+import { IHaConnection } from "../home-assistant/haConnection";
+
+export class DomainCompletionContribution implements JSONWorkerContribution {
+  public static propertyMatches: string[] = [
+    "integration",
+    "domain",
+    "include_domains",
+    "exclude_domains",
+    "domains",
+  ];
+
+  constructor(private haConnection: IHaConnection) {}
+
+  public collectDefaultCompletions(
+    resource: string,
+    result: CompletionsCollector
+  ): Thenable<any> {
+    return Promise.resolve(null);
+  }
+
+  public collectPropertyCompletions = async (
+    resource: string,
+    location: JSONPath,
+    currentWord: string,
+    addValue: boolean,
+    isLast: boolean,
+    result: CompletionsCollector
+  ): Promise<any> => {
+    if (location.length < 2) {
+      return;
+    }
+    const currentNode = location[location.length - 1];
+    const parentNode = location[location.length - 2]; // in case or arrays, currentNode is the indexer for the array position
+    if (
+      !DomainCompletionContribution.propertyMatches.some(
+        (x) =>
+          x === currentNode || (!Number.isNaN(+currentNode) && x === parentNode)
+      )
+    ) {
+      return;
+    }
+    const domainCompletions = await this.haConnection.getDomainCompletions();
+    domainCompletions.forEach((c) => result.add(c));
+  };
+
+  public collectValueCompletions = async (
+    resource: string,
+    location: JSONPath,
+    currentKey: string,
+    result: CompletionsCollector
+  ): Promise<any> => {
+    if (
+      !DomainCompletionContribution.propertyMatches.some(
+        (x) => x === currentKey
+      )
+    ) {
+      return;
+    }
+
+    const domainCompletions = await this.haConnection.getEntityCompletions();
+    domainCompletions.forEach((c) => result.add(c));
+  };
+
+  public getInfoContribution(
+    resource: string,
+    location: JSONPath
+  ): Thenable<MarkedString[]> {
+    return Promise.resolve([]);
+  }
+}

--- a/src/language-service/src/haLanguageService.ts
+++ b/src/language-service/src/haLanguageService.ts
@@ -22,6 +22,7 @@ import { SchemaServiceForIncludes } from "./schemas/schemaService";
 import { EntityIdCompletionContribution } from "./completionHelpers/entityIds";
 import { HaConnection } from "./home-assistant/haConnection";
 import { ServicesCompletionContribution } from "./completionHelpers/services";
+import { DomainCompletionContribution } from "./completionHelpers/domains";
 import { DefinitionProvider } from "./definition/definition";
 import { HomeAssistantConfiguration } from "./haConfig/haConfig";
 import { Includetype } from "./haConfig/dto";
@@ -279,6 +280,7 @@ export class HomeAssistantLanguageService {
     const properties: { [provider: string]: string[] } = {};
     properties.entities = EntityIdCompletionContribution.propertyMatches;
     properties.services = ServicesCompletionContribution.propertyMatches;
+    properties.domains = DomainCompletionContribution.propertyMatches;
 
     const additionalCompletionProvider = this.findAutoCompletionProperty(
       document,
@@ -292,6 +294,13 @@ export class HomeAssistantLanguageService {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         if (!currentCompletions.items.some((x) => x.data && x.data.isEntity)) {
           additionalCompletion = await this.haConnection.getEntityCompletions();
+        }
+        break;
+      case "domains":
+        // sometimes the domains are already added, do not add them twice
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        if (!currentCompletions.items.some((x) => x.data && x.data.isDomain)) {
+          additionalCompletion = await this.haConnection.getDomainCompletions();
         }
         break;
       case "services":


### PR DESCRIPTION
This PR adds auto-completion support for domains. Based on the entity data we already got from Home Assistant, the domains got extracted from those.

![image](https://user-images.githubusercontent.com/195327/112300583-4a568080-8c99-11eb-86a0-0cda76d615bb.png)
