### PR TITLE
Simplify automation Blueprint schema

### DIFF
--- a/src/language-service/src/schemas/integrations/core/automation.ts
+++ b/src/language-service/src/schemas/integrations/core/automation.ts
@@ -90,7 +90,7 @@ interface BaseItem {
   condition?: Condition | Condition[] | IncludeList;
 }
 
-interface AutomationItem extends BaseItem {
+export interface AutomationItem extends BaseItem {
   /**
    * Triggers describe events that should trigger the automation rule.
    * https://www.home-assistant.io/docs/automation/#automation-basics

--- a/src/language-service/src/schemas/integrations/core/blueprint.ts
+++ b/src/language-service/src/schemas/integrations/core/blueprint.ts
@@ -5,22 +5,18 @@
  * - https://github.com/home-assistant/core/blob/dev/homeassistant/components/blueprint/models.py
  * - https://github.com/home-assistant/core/blob/dev/homeassistant/components/blueprint/schemas.py
  */
-import { Data, Deprecated, IncludeList } from "../../types";
 import { Selector } from "../selectors";
-import { Mode } from "./automation";
-import { Action } from "../actions";
-import { Condition } from "../conditions";
-import { Trigger } from "../triggers";
+import { AutomationItem } from "./automation";
 
 export type Domain = "blueprint";
 export type Schema = null;
 
-export interface AutomationBlueprintFile {
+export interface AutomationBlueprint extends AutomationItem {
   /**
    * The blueprint schema.
    * https://www.home-assistant.io/docs/blueprint/schema/#the-blueprint-schema
    */
-  blueprint: AutomationBlueprint;
+  blueprint: Blueprint;
 }
 
 // export interface AutomationBlueprint extends AutomationItem, Blueprint {}
@@ -92,98 +88,4 @@ interface BlueprintInputSchema {
    * https://www.home-assistant.io/docs/blueprint/schema/#default
    */
   selector?: Selector;
-}
-
-export interface AutomationBlueprint extends Blueprint {
-  /**
-   * A unique identifier for this automation.
-   * Do not use the same twice, ever!
-   * https://www.home-assistant.io/docs/automation/
-   */
-  id?: string;
-
-  /**
-   * The domain name this blueprint provides a blueprint for.
-   * https://www.home-assistant.io/docs/blueprint/schema/#domain
-   */
-  domain: "automation";
-
-  /**
-   * Alias will be used to generate an entity_id from.
-   * https://www.home-assistant.io/docs/automation/
-   */
-  alias?: string;
-
-  /**
-   * Description of the automation.
-   * This is helpful to know what the automation does.
-   * https://www.home-assistant.io/docs/automation/
-   */
-  description?: string;
-
-  /**
-   * DEPRECATED since Home Assistant 0.112.
-   * This option has no effect. Please remove it from your configuration.
-   */
-  hide_entity?: Deprecated;
-
-  /**
-   * When you create a new automation, it will be enabled unless you explicitly add initial_state: false to it or turn it off manually via UI/another automation/developer tools.
-   * In case automations need to be always enabled or disabled when Home Assistant starts, then you can set the initial_state in your automations. Otherwise, the previous state will be restored.
-   * https://www.home-assistant.io/docs/automation/#automation-initial-state
-   */
-  initial_state?: boolean;
-
-  /**
-   * For both queued and parallel modes, configuration option max controls the maximum number of runs that can be executing and/or queued up at a time. The default is 10.
-   * https://www.home-assistant.io/docs/automation/#automation-modes
-   *
-   * @minimum 2
-   */
-  max?: number;
-
-  /**
-   * The automation’s mode configuration option controls what happens when the automation is triggered while the actions are still running from a previous trigger.
-   * https://www.home-assistant.io/docs/automation/#automation-modes
-   */
-  mode?: Mode;
-
-  /**
-   * When `max` is exceeded (which is effectively 1 for `single` mode) a log message will be emitted to indicate this has happened. This controls the severity level of that log message
-   * https://www.home-assistant.io/docs/automation/#automation-modes
-   */
-  max_exceeded?:
-    | "silent"
-    | "notset"
-    | "debug"
-    | "info"
-    | "warn"
-    | "warning"
-    | "error"
-    | "fatal"
-    | "critical";
-
-  /**
-   * Variables that will be available inside your templates and conditions.
-   * https://www.home-assistant.io/docs/automation/#automation-basics
-   */
-  variables?: Data;
-
-  /**
-   * Conditions are optional tests that can limit an automation rule to only work in your specific use cases. A condition will test against the current state of the system. This includes the current time, devices, people and other things like the sun.
-   * https://www.home-assistant.io/docs/automation/#automation-basics
-   */
-  condition?: Condition | Condition[] | IncludeList;
-
-  /**
-   * Triggers describe events that should trigger the automation rule.
-   * https://www.home-assistant.io/docs/automation/#automation-basics
-   */
-  trigger: Trigger | Trigger[] | IncludeList;
-
-  /**
-   * The action(s) which will be performed when a rule is triggered and all conditions are met. For example, it can turn a light on, set the temperature on your thermostat or activate a scene.
-   * https://www.home-assistant.io/docs/automation/#automation-basics
-   */
-  action: Action | Action[] | IncludeList;
 }

--- a/src/language-service/src/schemas/mappings.json
+++ b/src/language-service/src/schemas/mappings.json
@@ -179,6 +179,6 @@
     "path": "blueprints/automation",
     "file": "blueprint-automation.json",
     "tsFile": "integrations/core/blueprint.ts",
-    "fromType": "AutomationBlueprintFile"
+    "fromType": "AutomationBlueprint"
   }
 ]


### PR DESCRIPTION
Simplification of the Automation Blueprint schema, but extending the existing automation schema to add the blueprint logic.

Less code, same result.

Initially didn't do this, because I was afraid our schema generator didn't work with this, but it does pick it up correctly.