### PR TITLE
Pick up automations folders & files

### DIFF
--- a/src/language-service/src/haConfig/haConfig.ts
+++ b/src/language-service/src/haConfig/haConfig.ts
@@ -101,7 +101,7 @@ export class HomeAssistantConfiguration {
   private getRootFiles = (): string[] => {
     const filesInRoot = this.fileAccessor.getFilesInFolder("");
     const ourFiles = ["configuration.yaml", "ui-lovelace.yaml"];
-    const ourFolders = ["blueprints/automation/"];
+    const ourFolders = ["blueprints/automation/", "automations/"];
 
     const rootFiles = ourFiles.filter((f) => filesInRoot.some((y) => y === f));
     const subfolderFiles = filesInRoot.filter((f) =>

--- a/src/language-service/src/haConfig/haConfig.ts
+++ b/src/language-service/src/haConfig/haConfig.ts
@@ -100,7 +100,11 @@ export class HomeAssistantConfiguration {
 
   private getRootFiles = (): string[] => {
     const filesInRoot = this.fileAccessor.getFilesInFolder("");
-    const ourFiles = ["configuration.yaml", "ui-lovelace.yaml"];
+    const ourFiles = [
+      "configuration.yaml",
+      "ui-lovelace.yaml",
+      "automations.yaml",
+    ];
     const ourFolders = ["blueprints/automation/", "automations/"];
 
     const rootFiles = ourFiles.filter((f) => filesInRoot.some((y) => y === f));

--- a/src/language-service/src/schemas/schemaService.ts
+++ b/src/language-service/src/schemas/schemaService.ts
@@ -39,7 +39,10 @@ export class SchemaServiceForIncludes {
         sourceFileMappingPath = "blueprints/automation";
       }
 
-      if (sourceFileMappingPath.startsWith("automations/")) {
+      if (
+        sourceFileMappingPath.startsWith("automations/") ||
+        sourceFileMappingPath === "automations.yaml"
+      ) {
         sourceFileMappingPath = "configuration.yaml/automation";
       }
 

--- a/src/language-service/src/schemas/schemaService.ts
+++ b/src/language-service/src/schemas/schemaService.ts
@@ -39,6 +39,10 @@ export class SchemaServiceForIncludes {
         sourceFileMappingPath = "blueprints/automation";
       }
 
+      if (sourceFileMappingPath.startsWith("automations/")) {
+        sourceFileMappingPath = "configuration.yaml/automation";
+      }
+
       const relatedPathToSchemaMapping = this.mappings.find(
         (x) => x.path === sourceFileMappingPath
       );
@@ -51,6 +55,10 @@ export class SchemaServiceForIncludes {
         absolutePath = absolutePath.replace("\\", "/");
         const fileass = encodeURI(absolutePath);
         let resultEntry = results.find((x) => x.uri === id);
+
+        console.log(
+          `Assigning ${fileass} the ${relatedPathToSchemaMapping.path} schema`
+        );
 
         if (!resultEntry) {
           resultEntry = {


### PR DESCRIPTION
Since we now support folders, having automations in a 'automations/' subfolder is a fairly common pattern. Additionally, `automations.yaml` in the root folder is managed by the UI on a fixed location, thus safe to assume it are automations.

Depending on how your setup works, this might not get picked up by the extension (multiple split packages layers for example).

This PR ensures both the automations file and files in the automations folder is picked up.

Extra: Added a small message to the log output that shows which files get assigned which schema.

![image](https://user-images.githubusercontent.com/195327/112311816-657bbd00-8ca6-11eb-8e20-fa69bc4366fe.png)
