### PR TITLE
Blueprint input default can be any type

### DIFF
--- a/src/language-service/src/schemas/integrations/core/blueprint.ts
+++ b/src/language-service/src/schemas/integrations/core/blueprint.ts
@@ -81,7 +81,7 @@ interface BlueprintInputSchema {
    * The default value of this input, in case the input is not provided by the user of this blueprint.
    * https://www.home-assistant.io/docs/blueprint/schema/#default
    */
-  default?: string;
+  default?: any;
 
   /**
    * The default value of this input, in case the input is not provided by the user of this blueprint.


### PR DESCRIPTION
A Blueprints default value for an input can be anything. Adjusting the schema for that.