### PR TITLE
Allow use boolean as state in state conditon

### DIFF
--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -330,7 +330,7 @@ export type PositiveInteger = number;
  */
 export type Port = number;
 
-export type State = number | string;
+export type State = boolean | number | string;
 export type Template = string;
 
 /**


### PR DESCRIPTION
The extension shows error for boolean value of attribute: `Incorrect type. Expected "array"`. There is a fix.