### PR TITLE
Add auto-completion for light and lights

### DIFF
--- a/src/language-service/src/completionHelpers/entityIds.ts
+++ b/src/language-service/src/completionHelpers/entityIds.ts
@@ -21,6 +21,8 @@ export class EntityIdCompletionContribution implements JSONWorkerContribution {
     "scene",
     "zone",
     "zones",
+    "light",
+    "lights"
   ];
 
   constructor(private haConnection: IHaConnection) {}

--- a/src/language-service/src/completionHelpers/entityIds.ts
+++ b/src/language-service/src/completionHelpers/entityIds.ts
@@ -22,7 +22,7 @@ export class EntityIdCompletionContribution implements JSONWorkerContribution {
     "zone",
     "zones",
     "light",
-    "lights"
+    "lights",
   ];
 
   constructor(private haConnection: IHaConnection) {}

--- a/src/language-service/src/completionHelpers/entityIds.ts
+++ b/src/language-service/src/completionHelpers/entityIds.ts
@@ -18,11 +18,11 @@ export class EntityIdCompletionContribution implements JSONWorkerContribution {
     "exclude_entities",
     "geo_location",
     "include_entities",
+    "light",
+    "lights",
     "scene",
     "zone",
     "zones",
-    "light",
-    "lights",
   ];
 
   constructor(private haConnection: IHaConnection) {}


### PR DESCRIPTION
Some integrations use light and lights properties instead of the usual entity or entities. 
This PR allows for auto-completion on these keywords.