### PR TITLE
Fix script via include_dir_named

### DIFF
--- a/src/language-service/src/schemas/integrations/core/script.ts
+++ b/src/language-service/src/schemas/integrations/core/script.ts
@@ -8,6 +8,7 @@ import { Selector } from "../selectors";
 
 export type Domain = "script";
 type Item = ScriptItem | BlueprintItem;
+export type File = Schema | ScriptItem | BlueprintItem;
 export interface Schema {
   [key: string]: Item | IncludeNamed;
 }

--- a/src/language-service/src/schemas/mappings.json
+++ b/src/language-service/src/schemas/mappings.json
@@ -53,7 +53,7 @@
     "path": "configuration.yaml/script",
     "file": "integration-script.json",
     "tsFile": "integrations/core/script.ts",
-    "fromType": "Schema"
+    "fromType": "File"
   },
   {
     "key": "integration-sensor",


### PR DESCRIPTION
Fixes #483

This makes sense now with Home Assistant 2021.4, which fixed split configs for scripts as well.