### PR TITLE
Add min/max/step to MQTT number

### DIFF
--- a/src/language-service/src/schemas/integrations/core/mqtt.ts
+++ b/src/language-service/src/schemas/integrations/core/mqtt.ts
@@ -2887,6 +2887,18 @@ export interface NumberPlatformSchema extends PlatformSchema {
   json_attributes_topic?: string;
 
   /**
+   * Maximum value.
+   * https://www.home-assistant.io/integrations/number.mqtt#max
+   */
+  max?: number;
+
+  /**
+   * Minimum value.
+   * https://www.home-assistant.io/integrations/number.mqtt#min
+   */
+  min?: number;
+
+  /**
    * The name of the MQTT number.
    * https://www.home-assistant.io/integrations/number.mqtt#name
    */
@@ -2915,6 +2927,12 @@ export interface NumberPlatformSchema extends PlatformSchema {
    * https://www.home-assistant.io/integrations/number.mqtt/#state_topic
    */
   state_topic?: string;
+
+  /**
+   * Step value. Smallest value `0.001`.
+   * https://www.home-assistant.io/integrations/number.mqtt/#step
+   */
+  step?: number;
 
   /**
    * An ID that uniquely identifies this number. If two numbers have the same unique ID, Home Assistant will raise an exception.


### PR DESCRIPTION
Adds min/max/step attributes to the MQTT number platform schema.

Added upstream in: https://github.com/home-assistant/core/pull/50869