### PR TITLE
Fix option schema definition for SelectSelector

### DIFF
--- a/src/language-service/src/schemas/integrations/selectors.ts
+++ b/src/language-service/src/schemas/integrations/selectors.ts
@@ -223,7 +223,7 @@ export interface SelectSelector {
      * List of options that the user can choose from.
      * https://www.home-assistant.io/docs/blueprint/selectors/#select-selector
      */
-    options: [string];
+    options: string[];
   };
 }
 


### PR DESCRIPTION
Fixes an array with a string vs an array of strings in the schema definition of the options list in the select selector.

fixes #1295