### PR TITLE
Fix Time definition to allow specification without seconds

### DIFF
--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -314,8 +314,8 @@ interface TimeTrigger {
    * Time of day to trigger on, in HH:MM:SS, 24 hours clock format. For example: "13:30:00"
    * Also accepts input_datetime entities (e.g., input_datetime.start_of_day)
    *
-   * @TJS-pattern ^(input_datetime\.(?!_)[\da-z_]+(?<!_)\s?(?:,\s?input_datetime\.(?!_)[\da-z_]+(?<!_))*|(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d))$
-   * @items.pattern ^(input_datetime\.(?!_)[\da-z_]+(?<!_)|(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d))$
+   * @TJS-pattern ^(input_datetime\.(?!_)[\da-z_]+(?<!_)\s?(?:,\s?input_datetime\.(?!_)[\da-z_]+(?<!_))*|(?:[01]\d|2[0123]):(?:[012345]\d)(:(?:[012345]\d))?)$
+   * @items.pattern ^(input_datetime\.(?!_)[\da-z_]+(?<!_)|(?:[01]\d|2[0123]):(?:[012345]\d)(:(?:[012345]\d))?)$
    */
   at: Times | InputDatetimeEntities;
 }

--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -351,8 +351,8 @@ export type DynamicTemplate = string;
 export type Time = string;
 
 /**
- * @TJS-pattern ^(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)$
- * @items.pattern ^(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)$
+ * @TJS-pattern ^(?:[01]\d|2[0123]):(?:[012345]\d)(:(?:[012345]\d))?$
+ * @items.pattern ^(?:[01]\d|2[0123]):(?:[012345]\d)(:(?:[012345]\d))?$
  */
 export type Times = string | string[];
 


### PR DESCRIPTION
As pointed out and fixes #1293 

`10:00` without setting the seconds, is a valid trigger time.