### PR TITLE
Add sensor/number reference in numeric triggers and conditions

### DIFF
--- a/src/language-service/src/schemas/integrations/conditions.ts
+++ b/src/language-service/src/schemas/integrations/conditions.ts
@@ -10,6 +10,7 @@ import {
   IncludeList,
   InputDatetimeEntity,
   InputNumberEntity,
+  NumberEntity,
   PersonEntities,
   SensorEntity,
   State,
@@ -114,13 +115,13 @@ export interface NumericStateCondition {
    * Passes if the numeric state of the given entity (or entities) is above the given threshold.
    * https://www.home-assistant.io/docs/scripts/conditions/#numeric-state-condition
    */
-  above?: number | InputNumberEntity;
+  above?: number | InputNumberEntity | NumberEntity | SensorEntity;
 
   /**
    * Passes if the numeric state of the given entity (or entities) is below the given threshold.
    * https://www.home-assistant.io/docs/scripts/conditions/#numeric-state-condition
    */
-  below?: number | InputNumberEntity;
+  below?: number | InputNumberEntity | NumberEntity | SensorEntity;
 
   /**
    * The entity ID or list of entity IDs to test the numeric state against.

--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -15,6 +15,8 @@ import {
   PersonEntities,
   ZoneEntities,
   SensorEntities,
+  NumberEntity,
+  SensorEntity,
 } from "../types";
 
 export type Trigger =
@@ -199,13 +201,13 @@ interface NumericStateTrigger {
    * Fire this trigger if the numeric state of the monitored entity (or entities) is changing from above to below the given threshold.
    * https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger
    */
-  below?: number | InputNumberEntity;
+  below?: number | InputNumberEntity | NumberEntity | SensorEntity;
 
   /**
    * Fire this trigger if the numeric state of the monitored entity (or entities) is changing from below to above the given threshold.
    * https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger
    */
-  above?: number | InputNumberEntity;
+  above?: number | InputNumberEntity | NumberEntity | SensorEntity;
 
   /**
    * An optional value template to use as the numeric state value.

--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -237,6 +237,17 @@ export type MediaPlayerEntity = string;
 export type MediaPlayerEntities = string | string[];
 
 /**
+ * @TJS-pattern ^number\.(?!_)[\da-z_]+(?<!_)$
+ */
+export type NumberEntity = string;
+
+/**
+ * @TJS-pattern ^number\.(?!_)[\da-z_]+(?<!_)\s?(?:,\s?number\.(?!_)[\da-z_]+(?<!_))*$
+ * @items.pattern ^number\.(?!_)[\da-z_]+(?<!_)$
+ */
+export type NumberEntities = string | string[];
+
+/**
  * @TJS-pattern ^person\.(?!_)[\da-z_]+(?<!_)$
  */
 export type PersonEntity = string;


### PR DESCRIPTION
```yaml
condition:
  - condition: numeric_state
    entity_id: sensor.outside_temperature
    above: sensor.inside_temperature
```

Added upstream in: https://github.com/home-assistant/core/pull/51439