### PR TITLE
Add active_state_address and command_value_state_address to KNX climate

### DIFF
--- a/src/language-service/src/schemas/integrations/core/knx.ts
+++ b/src/language-service/src/schemas/integrations/core/knx.ts
@@ -391,6 +391,18 @@ interface BinarySensor {
 
 interface Climate {
   /**
+   * KNX address for reading current activity. `0` is idle, `1` is active. DPT 1
+   * https://www.home-assistant.io/integrations/knx#active_state_addres
+   */
+  active_state_address?: GroupAddresses;
+
+  /**
+   * KNX address for reading current command value in percent. `0` sets the climate entity to idle if `active_state_address` is not set. DPT 5.001
+   * https://www.home-assistant.io/integrations/knx#command_value_state_address
+   */
+  command_value_state_address?: GroupAddresses;
+
+  /**
    * KNX address for switching between heat/cool mode. DPT 1.100
    * https://www.home-assistant.io/integrations/knx#heat_cool_address
    */

--- a/src/language-service/src/schemas/integrations/core/knx.ts
+++ b/src/language-service/src/schemas/integrations/core/knx.ts
@@ -403,18 +403,6 @@ interface Climate {
   command_value_state_address?: GroupAddresses;
 
   /**
-   * KNX address for switching between heat/cool mode. DPT 1.100
-   * https://www.home-assistant.io/integrations/knx#heat_cool_address
-   */
-  heat_cool_address?: GroupAddresses;
-
-  /**
-   * KNX address for reading heat/cool mode. DPT 1.100
-   * https://www.home-assistant.io/integrations/knx#heat_cool_state_address
-   */
-  heat_cool_state_address?: GroupAddresses;
-
-  /**
    * KNX address for setting HVAC controller modes. DPT 20.105
    * https://www.home-assistant.io/integrations/knx#controller_mode_address
    */
@@ -443,6 +431,18 @@ interface Climate {
    * https://www.home-assistant.io/integrations/knx#controller_status_state_address
    */
   controller_status_state_address?: GroupAddresses;
+
+  /**
+   * KNX address for switching between heat/cool mode. DPT 1.100
+   * https://www.home-assistant.io/integrations/knx#heat_cool_address
+   */
+  heat_cool_address?: GroupAddresses;
+
+  /**
+   * KNX address for reading heat/cool mode. DPT 1.100
+   * https://www.home-assistant.io/integrations/knx#heat_cool_state_address
+   */
+  heat_cool_state_address?: GroupAddresses;
 
   /**
    * Override the minimum temperature.


### PR DESCRIPTION
Add active_state_address and command_value_state_address to KNX climate
https://github.com/home-assistant/core/pull/52006