### PR TITLE
Add onLanguage activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "activationEvents": [
     "workspaceContains:**/configuration.yaml",
     "workspaceContains:**/ui-lovelace.yaml",
+    "onLanguage:home-assistant",
     "onFileSystem:ftp",
     "onFileSystem:ssh",
     "onFileSystem:sftp"


### PR DESCRIPTION
For some reason, the extension was not activating from my `/config/configuration.yaml`, but creating `/test/configuration.yaml` did cause it to activate. I checked permissions and they were both the same.

To reduce issues where the extension is failing to activate like this, this adds a language activation event as a backup. I've tested this locally by editing my installed extension files and it "solved" the issue.