### PR TITLE
Fix missing unique_id in Weather template

### DIFF
--- a/src/language-service/src/schemas/integrations/core/template.ts
+++ b/src/language-service/src/schemas/integrations/core/template.ts
@@ -253,6 +253,12 @@ export interface WeatherPlatformSchema extends PlatformSchema {
   temperature_template: Template;
 
   /**
+   * An ID that uniquely identifies this weather entity. Set this to a unique value to allow customization through the UI.
+   * https://www.home-assistant.io/integrations/weather.template#unique_id
+   */
+  unique_id?: string;
+
+  /**
    * The current visibility.
    * https://www.home-assistant.io/integrations/weather.template#visibility_template
    */


### PR DESCRIPTION
Add missing `unique_id` to the weather template schema.

fixes #1375