### PR TITLE
Add support for trigger_variables in automations

### DIFF
--- a/src/language-service/src/schemas/integrations/core/automation.ts
+++ b/src/language-service/src/schemas/integrations/core/automation.ts
@@ -110,6 +110,12 @@ export interface AutomationItem extends BaseItem {
   trigger: Trigger | Trigger[] | IncludeList;
 
   /**
+   * Available in trigger templates with the difference that only limited templates can be used to pass a value to the trigger variable.
+   * https://www.home-assistant.io/docs/automation/trigger#trigger-variables
+   */
+  trigger_variables?: Data;
+
+  /**
    * The action(s) which will be performed when a rule is triggered and all conditions are met. For example, it can turn a light on, set the temperature on your thermostat or activate a scene.
    * https://www.home-assistant.io/docs/automation/#automation-basics
    */


### PR DESCRIPTION
Adds support for using trigger variables in automations:

```yaml
automation:
   - alias: "My Automation"
     trigger_variables:
       my_variable: "light.office"
     ...
```

closes hassio-addons/addon-vscode#288