### PR TITLE
Add needle support to Lovelace Gauge Card

### DIFF
--- a/src/language-service/src/schemas/lovelace/cards/gauge.ts
+++ b/src/language-service/src/schemas/lovelace/cards/gauge.ts
@@ -40,6 +40,12 @@ export interface Schema {
   name?: string;
 
   /**
+   * Show the gauge as a needle gauge.
+   * https://www.home-assistant.io/lovelace/gauge/#needle
+   */
+  needle?: boolean;
+
+  /**
    * Allows setting of colors for different numbers.
    * https://www.home-assistant.io/lovelace/gauge/#severity
    */


### PR DESCRIPTION
Adds support for the new gauge card needle option, that is added in Home Assistant 2021.8