### PR TITLE
Add support for the new Lovelace sidebar view

### DIFF
--- a/src/language-service/src/schemas/lovelace/cards/alarm_panel.ts
+++ b/src/language-service/src/schemas/lovelace/cards/alarm_panel.ts
@@ -6,6 +6,7 @@
  *  - https://github.com/home-assistant/frontend/blob/dev/src/data/lovelace.ts
  */
 import { AlarmControlPanelEntity } from "../../types";
+import { ViewLayout } from "../types";
 
 type States = "arm_away" | "arm_custom_bypass" | "arm_home" | "arm_night";
 
@@ -39,4 +40,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/alarm-panel/#theme
    */
   theme?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/button.ts
+++ b/src/language-service/src/schemas/lovelace/cards/button.ts
@@ -7,6 +7,7 @@
  */
 import { Entity } from "../../types";
 import { Action } from "../actions";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -86,4 +87,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/button/#theme
    */
   theme?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/calendar.ts
+++ b/src/language-service/src/schemas/lovelace/cards/calendar.ts
@@ -6,6 +6,7 @@
  *  - https://github.com/home-assistant/frontend/blob/dev/src/data/lovelace.ts
  */
 import { Entity } from "../../types";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -37,4 +38,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/calendar/#title
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/conditional.ts
+++ b/src/language-service/src/schemas/lovelace/cards/conditional.ts
@@ -5,7 +5,7 @@
  *  - https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/cards/types.ts
  *  - https://github.com/home-assistant/frontend/blob/dev/src/data/lovelace.ts
  */
-import { Card, Condition } from "../types";
+import { Card, Condition, ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -25,4 +25,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/conditional/#conditions
    */
   conditions: Condition[];
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/energy_carbon_consumed_gauge.ts
+++ b/src/language-service/src/schemas/lovelace/cards/energy_carbon_consumed_gauge.ts
@@ -1,3 +1,5 @@
+import { ViewLayout } from "../types";
+
 /**
  * Lovelace Carbon consumed gauge Card
  * Sources:
@@ -14,4 +16,9 @@ export interface Schema {
    * The card title.
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/energy_date_selection.ts
+++ b/src/language-service/src/schemas/lovelace/cards/energy_date_selection.ts
@@ -1,3 +1,5 @@
+import { ViewLayout } from "../types";
+
 /**
  * Lovelace Energy Date Picker Card
  * Sources:
@@ -9,4 +11,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/energy/#energy-date-picker
    */
   type: "energy-date-selection";
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/energy_devices_graph.ts
+++ b/src/language-service/src/schemas/lovelace/cards/energy_devices_graph.ts
@@ -1,3 +1,5 @@
+import { ViewLayout } from "../types";
+
 /**
  * Lovelace Devices energy graph Card
  * Sources:
@@ -14,4 +16,9 @@ export interface Schema {
    * The card title.
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/energy_distribution.ts
+++ b/src/language-service/src/schemas/lovelace/cards/energy_distribution.ts
@@ -1,3 +1,5 @@
+import { ViewLayout } from "../types";
+
 /**
  * Lovelace Energy distribution Card
  * Sources:
@@ -14,4 +16,9 @@ export interface Schema {
    * The card title.
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/energy_grid_neutrality_gauge.ts
+++ b/src/language-service/src/schemas/lovelace/cards/energy_grid_neutrality_gauge.ts
@@ -1,3 +1,5 @@
+import { ViewLayout } from "../types";
+
 /**
  * Lovelace Grid neutrality gauge Card
  * Sources:
@@ -14,4 +16,9 @@ export interface Schema {
    * The card title.
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/energy_solar_consumed_gauge.ts
+++ b/src/language-service/src/schemas/lovelace/cards/energy_solar_consumed_gauge.ts
@@ -1,3 +1,5 @@
+import { ViewLayout } from "../types";
+
 /**
  * Lovelace Solar consumed gauge Card
  * Sources:
@@ -14,4 +16,9 @@ export interface Schema {
    * The card title.
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/energy_solar_graph.ts
+++ b/src/language-service/src/schemas/lovelace/cards/energy_solar_graph.ts
@@ -1,3 +1,5 @@
+import { ViewLayout } from "../types";
+
 /**
  * Lovelace Solar production graph Card
  * Sources:
@@ -14,4 +16,9 @@ export interface Schema {
    * The card title.
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/energy_sources_table.ts
+++ b/src/language-service/src/schemas/lovelace/cards/energy_sources_table.ts
@@ -1,3 +1,5 @@
+import { ViewLayout } from "../types";
+
 /**
  * Lovelace Energy sources table Card
  * Sources:
@@ -14,4 +16,9 @@ export interface Schema {
    * The card title.
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/energy_usage_graph.ts
+++ b/src/language-service/src/schemas/lovelace/cards/energy_usage_graph.ts
@@ -1,3 +1,5 @@
+import { ViewLayout } from "../types";
+
 /**
  * Lovelace Energy usage graph Card
  * Sources:
@@ -14,4 +16,9 @@ export interface Schema {
    * The card title.
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/entities.ts
+++ b/src/language-service/src/schemas/lovelace/cards/entities.ts
@@ -8,6 +8,7 @@
 import { Entity as EntityString } from "../../types";
 import { HeaderFooter } from "../headers_footers";
 import { Row } from "../rows";
+import { ViewLayout } from "../types";
 
 type Entity = EntityString | Row;
 
@@ -65,4 +66,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/entities/#title
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/entity.ts
+++ b/src/language-service/src/schemas/lovelace/cards/entity.ts
@@ -7,6 +7,7 @@
  */
 import { Entity } from "../../types";
 import { HeaderFooter } from "../headers_footers";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -56,4 +57,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/entity/#unit
    */
   unit?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/entity_filter.ts
+++ b/src/language-service/src/schemas/lovelace/cards/entity_filter.ts
@@ -6,7 +6,7 @@
  *  - https://github.com/home-assistant/frontend/blob/dev/src/data/lovelace.ts
  */
 import { Entity as EntityString } from "../../types";
-import { Card, EntityConfig } from "../types";
+import { Card, EntityConfig, ViewLayout } from "../types";
 
 type Entity = EntityString | EntityFilterEntityConfig;
 type StateFilter = StateFilterConfig | string;
@@ -41,6 +41,11 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/entity-filter/#state_filter
    */
   state_filter: StateFilter[];
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }
 
 interface EntityFilterEntityConfig extends EntityConfig {

--- a/src/language-service/src/schemas/lovelace/cards/gauge.ts
+++ b/src/language-service/src/schemas/lovelace/cards/gauge.ts
@@ -7,6 +7,7 @@
  */
 
 import { Entity } from "../../types";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -62,6 +63,11 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/gauge/#unit
    */
   unit?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }
 
 interface Severity {

--- a/src/language-service/src/schemas/lovelace/cards/glance.ts
+++ b/src/language-service/src/schemas/lovelace/cards/glance.ts
@@ -7,7 +7,7 @@
  */
 
 import { Action } from "../actions";
-import { EntityConfig } from "../types";
+import { EntityConfig, ViewLayout } from "../types";
 import { Entity as EntityString, PositiveInteger } from "../../types";
 
 type Entity = EntityString | GlanceEntityConfig;
@@ -66,6 +66,11 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/glance/#theme
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }
 
 interface GlanceEntityConfig extends EntityConfig {

--- a/src/language-service/src/schemas/lovelace/cards/grid.ts
+++ b/src/language-service/src/schemas/lovelace/cards/grid.ts
@@ -7,7 +7,7 @@
  */
 
 import { PositiveInteger } from "../../types";
-import { Card } from "../types";
+import { Card, ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -40,4 +40,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/grid/#title
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/history_graph.ts
+++ b/src/language-service/src/schemas/lovelace/cards/history_graph.ts
@@ -7,7 +7,7 @@
  */
 
 import { Entity as EntityString, PositiveInteger } from "../../types";
-import { EntityConfig } from "../types";
+import { EntityConfig, ViewLayout } from "../types";
 
 type Entity = EntityString | EntityConfig;
 
@@ -44,4 +44,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/history-graph/#title
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/horizontal_stack.ts
+++ b/src/language-service/src/schemas/lovelace/cards/horizontal_stack.ts
@@ -6,7 +6,7 @@
  *  - https://github.com/home-assistant/frontend/blob/dev/src/data/lovelace.ts
  */
 
-import { Card } from "../types";
+import { Card, ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -26,4 +26,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/horizontal-stack/#title
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/humidifier.ts
+++ b/src/language-service/src/schemas/lovelace/cards/humidifier.ts
@@ -6,6 +6,7 @@
  *  - https://github.com/home-assistant/frontend/blob/dev/src/data/lovelace.ts
  */
 import { HumidifierEntity } from "../../types";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -31,4 +32,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/humidifier/#theme
    */
   theme?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/iframe.ts
+++ b/src/language-service/src/schemas/lovelace/cards/iframe.ts
@@ -1,3 +1,5 @@
+import { ViewLayout } from "../types";
+
 /**
  * Lovelace Webpage/iframe Card
  * Sources:
@@ -29,4 +31,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/iframe/#url
    */
   url: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/light.ts
+++ b/src/language-service/src/schemas/lovelace/cards/light.ts
@@ -7,6 +7,7 @@
  */
 import { Action } from "../actions";
 import { LightEntity } from "../../types";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -56,4 +57,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/light/#theme
    */
   theme?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/logbook.ts
+++ b/src/language-service/src/schemas/lovelace/cards/logbook.ts
@@ -6,6 +6,7 @@
  *  - https://github.com/home-assistant/frontend/blob/dev/src/data/lovelace.ts
  */
 import { Entity, PositiveInteger } from "../../types";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -37,4 +38,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/logbook/#title
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/map.ts
+++ b/src/language-service/src/schemas/lovelace/cards/map.ts
@@ -10,7 +10,7 @@ import {
   GeoLocationEntity as GeoLocationEntityString,
   PositiveInteger,
 } from "../../types";
-import { EntityConfig } from "../types";
+import { EntityConfig, ViewLayout } from "../types";
 
 type Entity = EntityString | EntityConfig;
 type GeoLocationEntity = GeoLocationEntityString | "all";
@@ -63,4 +63,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/map/#hours_to_show
    */
   hours_to_show?: PositiveInteger;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/markdown.ts
+++ b/src/language-service/src/schemas/lovelace/cards/markdown.ts
@@ -6,6 +6,7 @@
  *  - https://github.com/home-assistant/frontend/blob/dev/src/data/lovelace.ts
  */
 import { Entity, PositiveInteger } from "../../types";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -42,4 +43,9 @@ export interface Schema {
    * Set to any theme within themes.yaml.
    */
   theme?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/media_control.ts
+++ b/src/language-service/src/schemas/lovelace/cards/media_control.ts
@@ -6,6 +6,7 @@
  *  - https://github.com/home-assistant/frontend/blob/dev/src/data/lovelace.ts
  */
 import { MediaPlayerEntity } from "../../types";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -25,4 +26,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/media-control/#name
    */
   name?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/picture.ts
+++ b/src/language-service/src/schemas/lovelace/cards/picture.ts
@@ -7,6 +7,7 @@
  */
 
 import { Action } from "../actions";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -44,4 +45,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/picture/#theme
    */
   theme?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/picture_elements.ts
+++ b/src/language-service/src/schemas/lovelace/cards/picture_elements.ts
@@ -7,6 +7,7 @@
  */
 import { CameraEntity } from "../../types";
 import { Element } from "../elements";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -68,4 +69,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/picture-elements/#title
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/picture_entity.ts
+++ b/src/language-service/src/schemas/lovelace/cards/picture_entity.ts
@@ -8,6 +8,7 @@
 
 import { Action } from "../actions";
 import { CameraEntity, Entity } from "../../types";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -99,4 +100,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/picture-entity/#theme
    */
   theme?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/picture_glance.ts
+++ b/src/language-service/src/schemas/lovelace/cards/picture_glance.ts
@@ -7,7 +7,7 @@
  */
 
 import { Action } from "../actions";
-import { EntityConfig } from "../types";
+import { EntityConfig, ViewLayout } from "../types";
 import { CameraEntity, Entity as EntityString } from "../../types";
 
 type Entity = EntityString | PictureGlanceEntityConfig;
@@ -102,6 +102,11 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/picture-glance/#title
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }
 
 interface PictureGlanceEntityConfig extends EntityConfig {

--- a/src/language-service/src/schemas/lovelace/cards/plant_status.ts
+++ b/src/language-service/src/schemas/lovelace/cards/plant_status.ts
@@ -7,6 +7,7 @@
  */
 
 import { PlantEntity } from "../../types";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -32,4 +33,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/plant-status/#theme
    */
   theme?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/sensor.ts
+++ b/src/language-service/src/schemas/lovelace/cards/sensor.ts
@@ -7,6 +7,7 @@
  */
 
 import { PositiveInteger, SensorEntity } from "../../types";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -80,4 +81,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/sensor/#unit
    */
   unit?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/shopping_list.ts
+++ b/src/language-service/src/schemas/lovelace/cards/shopping_list.ts
@@ -6,6 +6,8 @@
  *  - https://github.com/home-assistant/frontend/blob/dev/src/data/lovelace.ts
  */
 
+import { ViewLayout } from "../types";
+
 export interface Schema {
   /**
    * The Shopping List card allows you to add, edit, check-off, and clear items from your shopping list.
@@ -24,4 +26,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/shopping-list/#title
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/statistics_graph.ts
+++ b/src/language-service/src/schemas/lovelace/cards/statistics_graph.ts
@@ -7,7 +7,7 @@
  */
 
 import { Entity as EntityString, PositiveInteger } from "../../types";
-import { EntityConfig } from "../types";
+import { EntityConfig, ViewLayout } from "../types";
 
 type Entity = EntityString | EntityConfig;
 type StateType = "max" | "mean" | "min" | "sum";
@@ -50,4 +50,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/statistics-graph/#title
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/thermostat.ts
+++ b/src/language-service/src/schemas/lovelace/cards/thermostat.ts
@@ -7,6 +7,7 @@
  */
 
 import { ClimateEntity } from "../../types";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -32,4 +33,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/thermostat/#theme
    */
   theme?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/vertical_stack.ts
+++ b/src/language-service/src/schemas/lovelace/cards/vertical_stack.ts
@@ -6,7 +6,7 @@
  *  - https://github.com/home-assistant/frontend/blob/dev/src/data/lovelace.ts
  */
 
-import { Card } from "../types";
+import { Card, ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -26,4 +26,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/vertical-stack/#title
    */
   title?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/cards/weather_forecast.ts
+++ b/src/language-service/src/schemas/lovelace/cards/weather_forecast.ts
@@ -7,6 +7,7 @@
  */
 
 import { WeatherEntity } from "../../types";
+import { ViewLayout } from "../types";
 
 export interface Schema {
   /**
@@ -44,4 +45,9 @@ export interface Schema {
    * https://www.home-assistant.io/lovelace/weather-forecast/#theme
    */
   theme?: string;
+
+  /**
+   * Layout options for the view this card is in
+   */
+  view_layout?: ViewLayout;
 }

--- a/src/language-service/src/schemas/lovelace/types.ts
+++ b/src/language-service/src/schemas/lovelace/types.ts
@@ -103,3 +103,14 @@ export interface Badge {
   type?: string;
   [key: string]: any;
 }
+
+/**
+ * @TJS-additionalProperties true
+ */
+export interface ViewLayout {
+  /**
+   * Defines the position of the card in an sidebar view.
+   * https://www.home-assistant.io/lovelace/sidebar/#view_layoutposition
+   */
+  position?: "main" | "sidebar";
+}

--- a/src/language-service/src/schemas/lovelace/view.ts
+++ b/src/language-service/src/schemas/lovelace/view.ts
@@ -3,7 +3,7 @@ import { Badge, Card } from "./types";
 
 type Badges = Badge | Entity;
 
-export type View = MasonryView | PanelView | SidebarView;
+export type View = MasonryView | PanelView | SidebarView | CustomView;
 
 interface BaseView {
   /**
@@ -89,4 +89,14 @@ export interface SidebarView extends BaseView {
    * https://rc.home-assistant.io/lovelace/sidebar/
    */
   type: "sidebar";
+}
+
+/**
+ * @TJS-additionalProperties true
+ */
+export interface CustomView extends BaseView {
+  /**
+   * @TJS-pattern custom:(.*)$
+   */
+  type: string;
 }

--- a/src/language-service/src/schemas/lovelace/view.ts
+++ b/src/language-service/src/schemas/lovelace/view.ts
@@ -1,9 +1,11 @@
-import { Entity, IncludeList } from "../types";
+import { Deprecated, Entity, IncludeList } from "../types";
 import { Badge, Card } from "./types";
 
 type Badges = Badge | Entity;
 
-export interface View {
+export type View = MasonryView | PanelView | SidebarView;
+
+interface BaseView {
   /**
    * Style the background using CSS.
    * https://www.home-assistant.io/lovelace/dashboards-and-views/#background
@@ -29,12 +31,6 @@ export interface View {
   icon?: string;
 
   /**
-   * Setting panel true sets the view to panel mode. In this mode the first card is rendered full-width, other cards in the view will not be rendered.
-   * https://www.home-assistant.io/lovelace/dashboards-and-views/#panel
-   */
-  panel?: boolean;
-
-  /**
    * You can link to one view from a card in another view when using cards that support navigation (navigation_path). The string supplied here will be appended to the string /lovelace/ to create the path to the view.
    * https://www.home-assistant.io/lovelace/dashboards-and-views/#path
    */
@@ -57,4 +53,40 @@ export interface View {
    * https://www.home-assistant.io/lovelace/dashboards-and-views/#visible
    */
   visible?: boolean | any;
+}
+
+export interface MasonryView extends BaseView {
+  /**
+   * The masonry view is the default view type. It sorts cards in columns based on their size.
+   * https://www.home-assistant.io/lovelace/masonry/
+   */
+  type?: "masonry";
+
+  /**
+   * List of entities IDs or badge objects to display as badges. Note that badges do not show when view is in panel mode.
+   * https://www.home-assistant.io/lovelace/dashboards-and-views/#badges
+   */
+  badges?: Badges[];
+
+  /**
+   * Deprecated, used "type: panel" instead.
+   * https://www.home-assistant.io/lovelace/dashboards-and-views/#panel
+   */
+  panel?: Deprecated;
+}
+
+export interface PanelView extends BaseView {
+  /**
+   * In this view the first card is rendered full-width, other cards in the view will not be rendered.
+   * https://www.home-assistant.io/lovelace/panel/
+   */
+  type: "panel";
+}
+
+export interface SidebarView extends BaseView {
+  /**
+   * The sidebar view has 2 columns, a wide one and a smaller one on the right.
+   * https://rc.home-assistant.io/lovelace/sidebar/
+   */
+  type: "sidebar";
 }


### PR DESCRIPTION
This PR brings support for the new `sidebar` view of Lovelace, which is introduced in 2021.8.
It will also deprecate the `panel` option, that is replaced with the `type: panel` instead.