### PR TITLE
Added missing effect_template to light template

### DIFF
--- a/src/language-service/src/schemas/integrations/core/template.ts
+++ b/src/language-service/src/schemas/integrations/core/template.ts
@@ -625,6 +625,12 @@ interface LightItem {
   effect_list_template?: Template;
 
   /**
+   * Defines a template to get the currently selected effect.
+   * https://www.home-assistant.io/integrations/light.template#effect_template
+   */
+  effect_template?: Template;
+
+  /**
    * Defines a template for the entity picture of the light.
    * https://www.home-assistant.io/integrations/light.template#entity_picture_template
    */


### PR DESCRIPTION
Schema for light template was missing `effect_template` field so VSCode showed an error when you added it in config even though the config was valid. This PR fixes it.