### PR TITLE
Added code_format field for template alarm

### DIFF
--- a/src/language-service/src/schemas/integrations/core/template.ts
+++ b/src/language-service/src/schemas/integrations/core/template.ts
@@ -303,6 +303,12 @@ interface AlarmControlPanelItem {
   code_arm_required?: boolean;
 
   /**
+   * Format for the code used to arm/disarm the alarm.
+   * https://www.home-assistant.io/integrations/alarm_control_panel.template/#code_format
+   */
+  code_format?: 'no_code' | 'number' | 'text';
+
+  /**
    * Defines an action to run when the alarm is disarmed.
    * https://www.home-assistant.io/integrations/alarm_control_panel.template/#disarm
    */

--- a/src/language-service/src/schemas/integrations/core/template.ts
+++ b/src/language-service/src/schemas/integrations/core/template.ts
@@ -306,7 +306,7 @@ interface AlarmControlPanelItem {
    * Format for the code used to arm/disarm the alarm.
    * https://www.home-assistant.io/integrations/alarm_control_panel.template/#code_format
    */
-  code_format?: 'no_code' | 'number' | 'text';
+  code_format?: "no_code" | "number" | "text";
 
   /**
    * Defines an action to run when the alarm is disarmed.


### PR DESCRIPTION
New field added in https://github.com/home-assistant/core/pull/56700, updating VSCode schema accordingly.