### PR TITLE
Update HACS token schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Evaluate jinja templates via Home Assistant's API and see how they would render.
 
 # Contribution
 
-- [How to update the schemas](https://github.com/keesschollaart81/vscode-home-assistant/wiki/HowTo:-Update-the-schemas)
-- [Local Development](https://github.com/keesschollaart81/vscode-home-assistant/wiki/Local-development)
+- [How to update the schemas](https://github.com/keesschollaart81/vscode-home-assistant/wiki/HowTo:-Update-the-schema's)
+- [Local Development](https://github.com/keesschollaart81/vscode-home-assistant/wiki/Local-development-of-this-Extension)
 
 # Release Notes
 

--- a/src/language-service/src/schemas/integrations/custom/hacs.ts
+++ b/src/language-service/src/schemas/integrations/custom/hacs.ts
@@ -9,7 +9,7 @@ export interface Schema {
    * Github Personal Access Token.
    * https://hacs.xyz/docs/configuration/legacy
    *
-   * @TJS-pattern ^[0-9a-fA-F]{40}$
+   * @TJS-pattern ^[0-9a-zA-Z_]{40}$
    */
   token: string;
 


### PR DESCRIPTION
I generated a new personal access token and got an error due to schema validation. My guess is that github changed the shape of their tokens since this schema was created. This PR makes the regex a bit more permissive to allow those new types of personal access tokens.

YAML with errors:
```YAML
hacs:
  token: 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 # don't worry this token has been deleted
```