### PR TITLE
Add JavaScript syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,6 +196,19 @@
         "injectTo": [
           "source.home-assistant"
         ]
+      },
+      {
+        "comments": [
+          "Support for JavaScript in triple square brackets"
+        ],
+        "path": "./syntaxes/home-assistant/javascript-brackets-block.tmLanguage",
+        "scopeName": "injection.homeassistant.javascript-brackets-block",
+        "embeddedLanguages": {
+          "meta.embedded.block.javascript": "javascript"
+        },
+        "injectTo": [
+          "source.home-assistant"
+        ]
       }
     ],
     "commands": [

--- a/syntaxes/home-assistant/javascript-brackets-block.tmLanguage
+++ b/syntaxes/home-assistant/javascript-brackets-block.tmLanguage
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>scopeName</key>
+        <string>injection.homeassistant.javascript-brackets-block</string>
+        <key>injectionSelector</key>
+        <string>L:string -meta.embedded.block.javascript</string>
+        <key>name</key>
+        <string>Grammar for JavaScript expressions surrounded by triple square brackets</string>
+        <key>patterns</key>
+        <array>
+            <dict>
+                <key>include</key>
+                <string>#javascript-expression</string>
+            </dict>
+        </array>
+        <key>repository</key>
+        <dict>
+            <key>javascript-expression</key>
+            <dict>
+                <key>comment</key>
+                <string>The 'name' is used to undo highlighting as string</string>
+                <key>name</key>
+                <string>keyword.operator.homeassistant</string>
+                <key>begin</key>
+                <string>\[\[\[</string>
+                <key>end</key>
+                <string>\]\]\]</string>
+                <key>beginCaptures</key>
+                <dict>
+                    <key>0</key>
+                    <dict>
+                        <key>name</key>
+                        <string>constant.character.escape.homeassistant</string>
+                    </dict>
+                </dict>
+                <key>endCaptures</key>
+                <dict>
+                    <key>0</key>
+                    <dict>
+                        <key>name</key>
+                        <string>constant.character.escape.homeassistant</string>
+                    </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.javascript</string>
+                <key>patterns</key>
+                <array>
+                    <dict>
+                        <key>include</key>
+                        <string>source.js</string>
+                    </dict>
+                </array>
+            </dict>
+        </dict>
+    </dict>
+</plist>


### PR DESCRIPTION
Adds JS syntax highlighting to the triple square bracket sections.

Before:
![image](https://user-images.githubusercontent.com/2270505/149609288-d0742489-8473-4454-9b54-f21fc62f6caf.png)

After:
![image](https://user-images.githubusercontent.com/2270505/149609291-200add4f-4942-4512-8081-659b8f6d89e1.png)
