### PR TITLE
Add built-in Jinja2 keywords

### DIFF
--- a/syntaxes/home-assistant/jinja-keywords.tmLanguage
+++ b/syntaxes/home-assistant/jinja-keywords.tmLanguage
@@ -12,6 +12,7 @@
         <array>
             <string>Extracted from:</string>
             <string>https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/template.py</string>
+            <string>https://jinja.palletsprojects.com/en/3.0.x/templates/#list-of-builtin-filters</string>
         </array>
         <key>patterns</key>
         <array>
@@ -29,7 +30,8 @@
                 <key>match</key>
                 <string>(?x)
                     \b(
-                        acos
+                        abs
+                        | acos
                         | area_devices
                         | area_entities
                         | area_id
@@ -40,20 +42,34 @@
                         | asin
                         | atan
                         | atan2
+                        | attr
                         | average
                         | base64_decode
                         | base64_encode
+                        | batch
                         | bitwise_and
                         | bitwise_or
+                        | capitalize
+                        | center
                         | closest
                         | cos
+                        | default
                         | device_attr
                         | device_entities
                         | device_id
+                        | dictsort
                         | distance
+                        | escape
                         | expand
+                        | filesizeformat
+                        | first
                         | float
+                        | forceescape
+                        | format
                         | from_json
+                        | groupby
+                        | iif
+                        | indent
                         | int
                         | integration_entities
                         | is_defined
@@ -61,7 +77,13 @@
                         | is_number
                         | is_state
                         | is_state_attr
+                        | join
+                        | last
+                        | length
+                        | list
                         | log
+                        | lower
+                        | map
                         | match
                         | max
                         | min
@@ -71,33 +93,56 @@
                         | ordinal
                         | pack
                         | pi
+                        | pprint
                         | random
                         | regex_findall
                         | regex_findall_index
                         | regex_match
                         | regex_replace
                         | regex_search
+                        | reject
+                        | rejectattr
                         | relative_time
+                        | replace
+                        | reverse
                         | round
+                        | safe
                         | search
+                        | select
+                        | selectattr
                         | sin
+                        | slice
+                        | sort
                         | sqrt
                         | state_attr
                         | states
+                        | string
+                        | striptags
                         | strptime
+                        | sum
                         | tan
                         | tau
                         | timedelta
                         | timestamp_custom
                         | timestamp_local
                         | timestamp_utc
+                        | title
                         | to_json
                         | today_at
+                        | tojson
+                        | trim
+                        | truncate
+                        | unique
                         | unpack
+                        | upper
                         | urlencode
+                        | urlize
                         | utcnow
                         | value
                         | value_json
+                        | wordcount
+                        | wordwrap
+                        | xmlattr
                     )\b
                 </string>
             </dict>


### PR DESCRIPTION
Home Assistant extends on top of the existing Jinja2 engine.
This means all existing built-in filters are also available.

This PR extends the syntax highlighting for the Jinja2 built-in keywords found in:

<https://jinja.palletsprojects.com/en/3.0.x/templates/#list-of-builtin-filters>

Additionally added `iif`, which is added in Home Assistant 2022.2:

<https://next.home-assistant.io/docs/configuration/templating/#immediate-if-iif>

![image](https://user-images.githubusercontent.com/195327/149656438-f101c08e-1af1-41e1-8f08-71745566f335.png)
