### PR TITLE
Added count filter

### DIFF
--- a/syntaxes/home-assistant/jinja-keywords.tmLanguage
+++ b/syntaxes/home-assistant/jinja-keywords.tmLanguage
@@ -53,6 +53,7 @@
                         | center
                         | closest
                         | cos
+                        | count
                         | default
                         | device_attr
                         | device_entities


### PR DESCRIPTION
I always use `| count` instead of `| length` and noticed this was not marked as a filter