### PR TITLE
Make `style` optional in divider entity row

### DIFF
--- a/src/language-service/src/schemas/lovelace/rows.ts
+++ b/src/language-service/src/schemas/lovelace/rows.ts
@@ -194,7 +194,7 @@ export interface DividerRow {
    * Style the element using CSS.
    * https://www.home-assistant.io/lovelace/entities/#style
    */
-  style: { [key: string]: any };
+  style?: { [key: string]: any };
 }
 
 interface EntityRow extends EntityConfig {


### PR DESCRIPTION
According to https://www.home-assistant.io/lovelace/entities/#divider, `style` is optional.