### PR TITLE
Update minimum value from 1 to 0 for input_text.min

### DIFF
--- a/src/language-service/src/schemas/integrations/core/input_text.ts
+++ b/src/language-service/src/schemas/integrations/core/input_text.ts
@@ -42,7 +42,7 @@ interface Item {
    * https://www.home-assistant.io/integrations/input_text#min
    *
    * @TJS-type integer
-   * @minimum 1
+   * @minimum 0
    * @maximum 255
    */
   min?: Integer;


### PR DESCRIPTION
Per https://www.home-assistant.io/integrations/input_text#min, the minimum value of `input_text.min` is 0, not 1.