### PR TITLE
Add webostv.turn_on trigger to triggers schema

### DIFF
--- a/src/language-service/src/schemas/integrations/core/webostv.ts
+++ b/src/language-service/src/schemas/integrations/core/webostv.ts
@@ -1,13 +1,13 @@
 export interface WebOSTvTrigger {
-    /**
-     * Trigger fires when WebOS integration attempts to turn on the TV.
-     * https://www.home-assistant.io/integrations/webostv/#configuration
-     */
-    platform: "webostv.turn_on";
-  
-    /**
-     * The entity ID of the TV that wants to get turned on.
-     * https://www.home-assistant.io/integrations/webostv/#configuration
-     */
-     entity_id?: string;
-  }
+  /**
+   * Trigger fires when WebOS integration attempts to turn on the TV.
+   * https://www.home-assistant.io/integrations/webostv/#configuration
+   */
+  platform: "webostv.turn_on";
+
+  /**
+   * The entity ID of the TV that wants to get turned on.
+   * https://www.home-assistant.io/integrations/webostv/#configuration
+   */
+  entity_id?: string;
+}

--- a/src/language-service/src/schemas/integrations/core/webostv.ts
+++ b/src/language-service/src/schemas/integrations/core/webostv.ts
@@ -1,0 +1,13 @@
+export interface WebOSTvTrigger {
+    /**
+     * Trigger fires when WebOS integration attempts to turn on the TV.
+     * https://www.home-assistant.io/integrations/webostv/#configuration
+     */
+    platform: "webostv.turn_on";
+  
+    /**
+     * The entity ID of the TV that wants to get turned on.
+     * https://www.home-assistant.io/integrations/webostv/#configuration
+     */
+     entity_id?: string;
+  }

--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -19,9 +19,7 @@ import {
   SensorEntity,
 } from "../types";
 
-import {
-  WebOSTvTrigger
-} from "./core/webostv";
+import { WebOSTvTrigger } from "./core/webostv";
 
 export type Trigger =
   | DeviceTrigger

--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -19,6 +19,10 @@ import {
   SensorEntity,
 } from "../types";
 
+import {
+  WebOSTvTrigger
+} from "./core/webostv";
+
 export type Trigger =
   | DeviceTrigger
   | EventTrigger
@@ -551,20 +555,6 @@ interface WebhookTrigger {
    * https://www.home-assistant.io/docs/automation/trigger#trigger-variables
    */
   variables?: Data;
-}
-
-interface WebOSTvTrigger {
-  /**
-   * Trigger fires when WebOS integration attempts to turn on the TV.
-   * https://www.home-assistant.io/integrations/webostv/#configuration
-   */
-  platform: "webostv.turn_on";
-
-  /**
-   * The entity ID of the TV that wants to get turned on.
-   * https://www.home-assistant.io/integrations/webostv/#configuration
-   */
-   entity_id?: string;
 }
 
 interface ZoneTrigger {

--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -33,6 +33,7 @@ export type Trigger =
   | TimeTrigger
   | TimePatternTrigger
   | WebhookTrigger
+  | WebOSTvTrigger
   | ZoneTrigger;
 
 type EventType =
@@ -550,6 +551,20 @@ interface WebhookTrigger {
    * https://www.home-assistant.io/docs/automation/trigger#trigger-variables
    */
   variables?: Data;
+}
+
+interface WebOSTvTrigger {
+  /**
+   * Trigger fires when WebOS integration attempts to turn on the TV.
+   * https://www.home-assistant.io/integrations/webostv/#configuration
+   */
+  platform: "webostv.turn_on";
+
+  /**
+   * The entity ID of the TV that wants to get turned on.
+   * https://www.home-assistant.io/integrations/webostv/#configuration
+   */
+   entity_id?: string;
 }
 
 interface ZoneTrigger {


### PR DESCRIPTION
Triger is used by WebOS tv integration to signal that it wants to turn on the TV: 

https://www.home-assistant.io/integrations/webostv/#configuration