### PR TITLE
Add "running" to DeviceClassesBinarySensor

### DIFF
--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -51,6 +51,7 @@ export type DeviceClassesBinarySensor =
   | "power"
   | "presence"
   | "problem"
+  | "running"
   | "safety"
   | "smoke"
   | "sound"


### PR DESCRIPTION
Adds `running` to `DeviceClassesBinarySensor`.

References [https://github.com/home-assistant/core/blob/dev/homeassistant/components/binary_sensor/__init__.py](https://github.com/home-assistant/core/blob/db10c313b5737c08e33b2dccdbf4f6ea01119966/homeassistant/components/binary_sensor/__init__.py#L95) which was added to Home Assistant in https://github.com/home-assistant/core/pull/58423.