### PR TITLE
Add KNX sensor type `latin_1`

### DIFF
--- a/src/language-service/src/schemas/integrations/core/knx.ts
+++ b/src/language-service/src/schemas/integrations/core/knx.ts
@@ -93,6 +93,7 @@ type ValueType =
   | "illuminance"
   | "impedance"
   | "kelvin_per_percent"
+  | "latin_1"
   | "length_mm"
   | "length"
   | "light_quantity"


### PR DESCRIPTION
There is a new sensor value type for string en/decoding supported by the KNX integration.

See https://github.com/home-assistant/home-assistant.io/pull/22252
