### PR TITLE
Add support for not_from and not_to in state trigger

### DIFF
--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -350,10 +350,22 @@ interface StateTrigger {
   from?: any | any[];
 
   /**
+   * The state the entity or entities NOT had before changing to its new state.
+   * https://www.home-assistant.io/docs/automation/trigger/#state-trigger
+   */
+   not_from?: any | any[];
+
+  /**
    * The state the entity or entities have changed to.
    * https://www.home-assistant.io/docs/automation/trigger/#state-trigger
    */
   to?: any | any[];
+
+  /**
+   * The state the entity or entities did NOT changed to.
+   * https://www.home-assistant.io/docs/automation/trigger/#state-trigger
+   */
+  not_to?: any | any[];
 
   /**
    * Use the value of a specific entity attribute to trigger on, instead of the entity state.

--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -353,7 +353,7 @@ interface StateTrigger {
    * The state the entity or entities NOT had before changing to its new state.
    * https://www.home-assistant.io/docs/automation/trigger/#state-trigger
    */
-   not_from?: any | any[];
+  not_from?: any | any[];
 
   /**
    * The state the entity or entities have changed to.


### PR DESCRIPTION
Home Assistant Core 2022.5 will provide a way NOT to trigger on certain states.
This PR adds support for that.