### PR TITLE
Add support for match any in a state condition

### DIFF
--- a/src/language-service/src/schemas/integrations/conditions.ts
+++ b/src/language-service/src/schemas/integrations/conditions.ts
@@ -260,6 +260,12 @@ export interface StateCondition {
    * https://www.home-assistant.io/docs/scripts/conditions/#state-condition
    */
   attribute?: string;
+
+  /**
+   * How to match in case this condition has multiple entity listed: "all" all entities have to match the state, "any" if any of the entities match the state.
+   * https://www.home-assistant.io/docs/scripts/conditions/#state-condition
+   */
+  match?: "any" | "all";
 }
 
 export interface SunCondition {


### PR DESCRIPTION
Support for matching any of the entity IDs in the state condition (instead of all, which is the default).

```yaml
condition:
  condition: state
  entity_id:
    - binary_sensor.motion_sensor_left
    - binary_sensor.motion_sensor_right
  match: any
  state: "on"
```

