### PR TITLE
Add support for enabling/disabling action/conditions/triggers

### DIFF
--- a/src/language-service/src/schemas/integrations/actions.ts
+++ b/src/language-service/src/schemas/integrations/actions.ts
@@ -38,6 +38,12 @@ export interface ChooseAction {
   alias?: string;
 
   /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
+
+  /**
    * Set it to true if you’d like to continue the action sequence, regardless of whether that action encounters an error.
    * https://www.home-assistant.io/docs/scripts/#continuing-on-error
    */
@@ -63,6 +69,11 @@ export interface ChooseActionItem {
   alias?: string;
 
   /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
+  /**
    * Only preform the sequence of actions if this condition/these conditions match.
    * https://www.home-assistant.io/docs/scripts/#choose-a-group-of-actions
    */
@@ -80,6 +91,12 @@ export interface DelayAction {
    * Alias for the delay action.
    */
   alias?: string;
+
+  /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
 
   /**
    * Set it to true if you’d like to continue the action sequence, regardless of whether that action encounters an error.
@@ -105,6 +122,12 @@ export interface DeviceAction {
   alias?: string;
 
   /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
+
+  /**
    * Set it to true if you’d like to continue the action sequence, regardless of whether that action encounters an error.
    * https://www.home-assistant.io/docs/scripts/#continuing-on-error
    */
@@ -128,6 +151,12 @@ export interface EventAction {
    * Alias for the Event action.
    */
   alias?: string;
+
+  /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
 
   /**
    * Set it to true if you’d like to continue the action sequence, regardless of whether that action encounters an error.
@@ -163,6 +192,12 @@ export interface IfAction {
   alias?: string;
 
   /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
+
+  /**
    * Set it to true if you’d like to continue the action sequence, regardless of whether that action encounters an error.
    * https://www.home-assistant.io/docs/scripts/#continuing-on-error
    */
@@ -194,6 +229,12 @@ export interface ParallelAction {
   alias?: string;
 
   /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
+
+  /**
    * Set it to true if you’d like to continue the action sequence, regardless of whether that action encounters an error.
    * https://www.home-assistant.io/docs/scripts/#continuing-on-error
    */
@@ -211,6 +252,12 @@ export interface RepeatAction {
    * Alias for the repeat action.
    */
   alias?: string;
+
+  /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
 
   /**
    * Set it to true if you’d like to continue the action sequence, regardless of whether that action encounters an error.
@@ -262,6 +309,12 @@ export interface SceneAction {
   alias?: string;
 
   /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
+
+  /**
    * Set it to true if you’d like to continue the action sequence, regardless of whether that action encounters an error.
    * https://www.home-assistant.io/docs/scripts/#continuing-on-error
    */
@@ -280,6 +333,12 @@ export interface ServiceAction {
    * https://www.home-assistant.io/docs/scripts/service-calls/
    */
   alias?: string;
+
+  /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
 
   /**
    * Set it to true if you’d like to continue the action sequence, regardless of whether that action encounters an error.
@@ -353,6 +412,12 @@ export interface WaitForTriggerAction {
   alias?: string;
 
   /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
+
+  /**
    * Set it to true if you’d like to continue the action sequence, regardless of whether that action encounters an error.
    * https://www.home-assistant.io/docs/scripts/#continuing-on-error
    */
@@ -384,6 +449,12 @@ export interface WaitTemplateAction {
   alias?: string;
 
   /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
+
+  /**
    * Set it to true if you’d like to continue the action sequence, regardless of whether that action encounters an error.
    * https://www.home-assistant.io/docs/scripts/#continuing-on-error
    */
@@ -413,6 +484,12 @@ export interface VariablesAction {
    * Alias for the variables action.
    */
   alias?: string;
+
+  /**
+   * Every individual action can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/#disabling-an-action
+   */
+  enabled?: boolean;
 
   /**
    * Set it to true if you’d like to continue the action sequence, regardless of whether that action encounters an error.

--- a/src/language-service/src/schemas/integrations/conditions.ts
+++ b/src/language-service/src/schemas/integrations/conditions.ts
@@ -48,6 +48,12 @@ export interface ShorthandCondition {
   alias?: string;
 
   /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
+
+  /**
    * The template condition has a shorthand notation that can be used to make your scripts and automations shorter.
    * https://www.home-assistant.io/docs/scripts/conditions/#template-condition-shorthand-notation
    */
@@ -59,6 +65,12 @@ export interface AndCondition {
    * Alias for the and condition.
    */
   alias?: string;
+
+  /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
 
   /**
    * Test multiple conditions in one condition statement. Passes if all embedded conditions are valid.
@@ -78,6 +90,11 @@ export interface AndShorthandCondition {
    * Alias for the and condition.
    */
   alias?: string;
+  /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
 
   /**
    * Test multiple conditions in one condition statement. Passes if all embedded conditions are valid.
@@ -94,6 +111,11 @@ export interface DeviceCondition {
    * Alias for the device condition.
    */
   alias?: string;
+  /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
 
   /**
    * Device conditions encompass a set of properties that are defined by an integration.
@@ -117,6 +139,11 @@ export interface NotCondition {
    * Alias for the not condition.
    */
   alias?: string;
+  /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
 
   /**
    * Test multiple conditions in one condition statement. Passes if all embedded conditions are not valid.
@@ -138,6 +165,11 @@ export interface NotShorthandCondition {
   alias?: string;
 
   /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
+  /**
    * Test multiple conditions in one condition statement. Passes if all embedded conditions are not valid.
    * https://www.home-assistant.io/docs/scripts/conditions/#not-condition
    */
@@ -149,6 +181,11 @@ export interface NumericStateCondition {
    * Alias for the numeric state condition.
    */
   alias?: string;
+  /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
 
   /**
    * This type of condition attempts to parse the state of the specified entity as a number, and triggers if the value matches the thresholds.
@@ -192,6 +229,11 @@ export interface OrCondition {
    * Alias for the or condition.
    */
   alias?: string;
+  /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
 
   /**
    * Test multiple conditions in one condition statement. Passes if any embedded condition is valid.
@@ -213,6 +255,11 @@ export interface OrShorthandCondition {
   alias?: string;
 
   /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
+  /**
    * Test multiple conditions in one condition statement. Passes if any embedded condition is valid.
    * https://www.home-assistant.io/docs/scripts/conditions/#or-condition
    */
@@ -225,6 +272,11 @@ export interface StateCondition {
    */
   alias?: string;
 
+  /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
   /**
    * Tests if an entity (or entities) is in a specified state.
    * https://www.home-assistant.io/docs/scripts/conditions/#state-condition
@@ -275,6 +327,11 @@ export interface SunCondition {
   alias?: string;
 
   /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
+  /**
    * The sun state can be used to test if the sun has set or risen.
    * https://www.home-assistant.io/docs/scripts/conditions/#sun-condition
    */
@@ -314,6 +371,11 @@ export interface TemplateCondition {
   alias?: string;
 
   /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
+  /**
    * The template condition tests if the given template renders a value equal to true. This is achieved by having the template result in a true boolean expression or by having the template render ‘true’.
    * https://www.home-assistant.io/docs/scripts/conditions/#template-condition
    */
@@ -332,6 +394,11 @@ export interface TimeCondition {
    */
   alias?: string;
 
+  /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
   /**
    * The time condition can test if it is after a specified time, before a specified time or if it is a certain day of the week.
    * https://www.home-assistant.io/docs/scripts/conditions/#time-condition
@@ -370,6 +437,11 @@ export interface TriggerCondition {
   alias?: string;
 
   /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
+  /**
    * The trigger condition can test if this automation was triggered by a specific trigger.
    * https://www.home-assistant.io/docs/scripts/conditions/#trigger-condition
    */
@@ -389,6 +461,12 @@ export interface ZoneCondition {
   alias?: string;
 
   condition: "zone";
+
+  /**
+   * Every individual condition can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/scripts/conditions/#disabling-a-condition
+   */
+  enabled?: boolean;
 
   /**
    * The entity ID(s) of the device tracker(s).

--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -69,6 +69,12 @@ interface DeviceTrigger {
   platform: "device";
 
   /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
+
+  /**
    * The internal ID of the device to trigger on
    * https://www.home-assistant.io/docs/automation/trigger/#device-triggers
    */
@@ -102,6 +108,12 @@ interface EventTrigger {
    * https://www.home-assistant.io/docs/automation/trigger/#event-trigger
    */
   platform: "event";
+
+  /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
 
   /**
    * Additional event context that has to match before triggering.
@@ -145,6 +157,12 @@ interface GeolocationTrigger {
   platform: "geo_location";
 
   /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
+
+  /**
    * Trigger when the entity leaves or enters the zone defined.
    * https://www.home-assistant.io/docs/automation/trigger/#geolocation-trigger
    */
@@ -186,6 +204,12 @@ interface HomeAssistantTrigger {
   platform: "homeassistant";
 
   /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
+
+  /**
    * Specified the event to listen to: Either the Home Assistant start or shutdown event.
    * https://www.home-assistant.io/docs/automation/trigger/#home-assistant-trigger
    */
@@ -213,6 +237,12 @@ interface MqttTrigger {
    * https://www.home-assistant.io/docs/automation/trigger/#mqtt-trigger
    */
   platform: "mqtt";
+
+  /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
 
   /**
    * The default payload encoding is ‘utf-8’.
@@ -273,6 +303,12 @@ interface NumericStateTrigger {
   platform: "numeric_state";
 
   /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
+
+  /**
    * The entity ID or list of entity IDs to monitor the numeric state for.
    * https://www.home-assistant.io/docs/automation/trigger/#numeric-state-trigger
    */
@@ -330,6 +366,12 @@ interface StateTrigger {
    * https://www.home-assistant.io/docs/automation/trigger/#state-trigger
    */
   platform: "state";
+
+  /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
 
   /**
    * The entity ID or list of entity IDs to monitor the state for.
@@ -397,6 +439,12 @@ interface SunTrigger {
   platform: "sun";
 
   /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
+
+  /**
    * The event to fire on, either on sunset or sunrise.
    * https://www.home-assistant.io/docs/automation/trigger/#sun-trigger
    */
@@ -430,6 +478,12 @@ interface TemplateTrigger {
    * https://www.home-assistant.io/docs/automation/trigger/#template-trigger
    */
   platform: "template";
+
+  /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
 
   /**
    * An personal identifier for this trigger, that is passed into the trigger
@@ -467,6 +521,12 @@ interface TimeTrigger {
   platform: "time";
 
   /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
+
+  /**
    * Time of day to trigger on, in HH:MM:SS, 24 hours clock format. For example: "13:30:00"
    * Also accepts input_datetime entities (e.g., input_datetime.start_of_day)
    *
@@ -497,6 +557,12 @@ interface TimePatternTrigger {
    * https://www.home-assistant.io/docs/automation/trigger/#time-pattern-trigger
    */
   platform: "time_pattern";
+
+  /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
 
   /**
    * An personal identifier for this trigger, that is passed into the trigger
@@ -543,6 +609,12 @@ interface WebhookTrigger {
   platform: "webhook";
 
   /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
+
+  /**
    * An personal identifier for this trigger, that is passed into the trigger
    * variables when the automation triggers using this trigger.
    * https://www.home-assistant.io/docs/automation/trigger/#webhook-trigger
@@ -570,6 +642,12 @@ interface ZoneTrigger {
    * https://www.home-assistant.io/docs/automation/trigger/#zone-trigger
    */
   platform: "zone";
+
+  /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
 
   /**
    * An personal identifier for this trigger, that is passed into the trigger
@@ -614,6 +692,12 @@ interface TagTrigger {
    * https://www.home-assistant.io/docs/automation/trigger#tag-trigger
    */
   platform: "tag";
+
+  /**
+   * Every individual trigger in an automation can be disabled, without removing it.
+   * https://www.home-assistant.io/docs/automation/trigger/#disabling-a-trigger
+   */
+  enabled?: boolean;
 
   /**
    * An personal identifier for this trigger, that is passed into the trigger


### PR DESCRIPTION
Home Assistant 2022.5 will have the possibility to enable/disable every single trigger/action/condition individually.

This PR adds support for that.