### PR TITLE
Update home-assistant-js-websocket to 7.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "axios": "^0.27.2",
         "bufferutil": "^4.0.6",
-        "home-assistant-js-websocket": "^7.0.4",
+        "home-assistant-js-websocket": "^7.0.5",
         "utf-8-validate": "^5.0.9",
         "vscode-extension-telemetry": "0.4.5",
         "vscode-json-languageservice": "3.9.1",
@@ -2958,9 +2958,9 @@
       }
     },
     "node_modules/home-assistant-js-websocket": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/home-assistant-js-websocket/-/home-assistant-js-websocket-7.0.4.tgz",
-      "integrity": "sha512-SXg8uTlr1GIMxFQDmLj8r6jxiicNPw4a9jWeWunlLY0nQiXqISKUCr5UFjcUhzKnbNoRS3nUEa4UxgQ9FEik9A=="
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/home-assistant-js-websocket/-/home-assistant-js-websocket-7.0.5.tgz",
+      "integrity": "sha512-THNFhUrNyW2hllMyme9/POdQ6hqxW/IIkmbnFP4VLU6jLKUUNfG31bNh/pBK/oNS9Arnu88D3JvHP+2cIj8/Eg=="
     },
     "node_modules/http-proxy-agent": {
       "version": "2.1.0",
@@ -8060,9 +8060,9 @@
       }
     },
     "home-assistant-js-websocket": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/home-assistant-js-websocket/-/home-assistant-js-websocket-7.0.4.tgz",
-      "integrity": "sha512-SXg8uTlr1GIMxFQDmLj8r6jxiicNPw4a9jWeWunlLY0nQiXqISKUCr5UFjcUhzKnbNoRS3nUEa4UxgQ9FEik9A=="
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/home-assistant-js-websocket/-/home-assistant-js-websocket-7.0.5.tgz",
+      "integrity": "sha512-THNFhUrNyW2hllMyme9/POdQ6hqxW/IIkmbnFP4VLU6jLKUUNfG31bNh/pBK/oNS9Arnu88D3JvHP+2cIj8/Eg=="
     },
     "http-proxy-agent": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -449,7 +449,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "bufferutil": "^4.0.6",
-    "home-assistant-js-websocket": "^7.0.4",
+    "home-assistant-js-websocket": "^7.0.5",
     "utf-8-validate": "^5.0.9",
     "vscode-extension-telemetry": "0.4.5",
     "vscode-json-languageservice": "3.9.1",

--- a/src/language-service/package-lock.json
+++ b/src/language-service/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.2",
-        "home-assistant-js-websocket": "^7.0.4",
+        "home-assistant-js-websocket": "^7.0.5",
         "vscode-json-languageservice": "3.9.1",
         "vscode-languageserver-protocol": "3.15.3",
         "vscode-uri": "3.0.3",
@@ -2819,9 +2819,9 @@
       }
     },
     "node_modules/home-assistant-js-websocket": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/home-assistant-js-websocket/-/home-assistant-js-websocket-7.0.4.tgz",
-      "integrity": "sha512-SXg8uTlr1GIMxFQDmLj8r6jxiicNPw4a9jWeWunlLY0nQiXqISKUCr5UFjcUhzKnbNoRS3nUEa4UxgQ9FEik9A=="
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/home-assistant-js-websocket/-/home-assistant-js-websocket-7.0.5.tgz",
+      "integrity": "sha512-THNFhUrNyW2hllMyme9/POdQ6hqxW/IIkmbnFP4VLU6jLKUUNfG31bNh/pBK/oNS9Arnu88D3JvHP+2cIj8/Eg=="
     },
     "node_modules/http-proxy-agent": {
       "version": "2.1.0",
@@ -7492,9 +7492,9 @@
       }
     },
     "home-assistant-js-websocket": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/home-assistant-js-websocket/-/home-assistant-js-websocket-7.0.4.tgz",
-      "integrity": "sha512-SXg8uTlr1GIMxFQDmLj8r6jxiicNPw4a9jWeWunlLY0nQiXqISKUCr5UFjcUhzKnbNoRS3nUEa4UxgQ9FEik9A=="
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/home-assistant-js-websocket/-/home-assistant-js-websocket-7.0.5.tgz",
+      "integrity": "sha512-THNFhUrNyW2hllMyme9/POdQ6hqxW/IIkmbnFP4VLU6jLKUUNfG31bNh/pBK/oNS9Arnu88D3JvHP+2cIj8/Eg=="
     },
     "http-proxy-agent": {
       "version": "2.1.0",

--- a/src/language-service/package.json
+++ b/src/language-service/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
-    "home-assistant-js-websocket": "^7.0.4",
+    "home-assistant-js-websocket": "^7.0.5",
     "vscode-json-languageservice": "3.9.1",
     "vscode-languageserver-protocol": "3.15.3",
     "vscode-uri": "3.0.3",


### PR DESCRIPTION
Fixes `ERR_INVALID_PACKAGE_TARGET`

https://github.com/home-assistant/home-assistant-js-websocket/releases/tag/7.0.5