### PR TITLE
Fix parallel action definition

### DIFF
--- a/src/language-service/src/schemas/integrations/actions.ts
+++ b/src/language-service/src/schemas/integrations/actions.ts
@@ -245,7 +245,16 @@ export interface ParallelAction {
    * The sequence of actions to run in parallel.
    * https://www.home-assistant.io/docs/scripts/#parallelizing-actions
    */
-  parallel: Action | Action[] | IncludeList;
+  parallel:
+    | (
+        | {
+            sequence: Action | Action[] | IncludeList;
+          }
+        | Action
+        | Action[]
+        | IncludeList
+      )[]
+    | IncludeList;
 }
 
 export interface RepeatAction {


### PR DESCRIPTION
fixes #2094

This is now valid:

```yaml
  - parallel:
      - - wait_for_trigger:
          - platform: state
            entity_id: binary_sensor.motion
            to: "on"
        - service: notify.person1
          data:
            message: "This message awaited the motion trigger"
      - sequence:
          - wait_for_trigger:
              - platform: state
                entity_id: binary_sensor.motion
                to: "on"
          - service: notify.person1
            data:
              message: "This message awaited the motion trigger"
      - service: notify.person2
        data:
          message: "I am sent immediately and do not await the above action!"
```