### PR TITLE
Add support for offset in calendar trigger

### DIFF
--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -85,6 +85,12 @@ interface CalendarTrigger {
   entity_id: CalendarEntity;
 
   /**
+   * Optional time offset to fire a set time before or after event start/end.
+   * https://www.home-assistant.io/docs/automation/trigger/#calendar-trigger
+   */
+  offset?: TimePeriod;
+
+  /**
    * An personal identifier for this trigger, that is passed into the trigger
    * variables when the automation triggers using this trigger.
    * https://www.home-assistant.io/docs/automation/trigger/#calendar-trigger


### PR DESCRIPTION
Add support for the new offset option on the calendar trigger. This is introduced in Home Assistant Core 2022.6