### PR TITLE
Handle frontend metadata correctly in service calls

### DIFF
--- a/src/language-service/src/schemas/integrations/actions.ts
+++ b/src/language-service/src/schemas/integrations/actions.ts
@@ -335,6 +335,11 @@ export interface SceneAction {
    * https://www.home-assistant.io/docs/scripts/#activate-a-scene
    */
   scene: SceneEntity;
+
+  /**
+   * Additional data for merely for use with the frontend. Has no functional effect.
+   */
+  metadata?: any;
 }
 
 export interface ServiceAction {
@@ -413,6 +418,11 @@ export interface ServiceAction {
         area_id?: Area | Area[] | "none";
       }
     | Template;
+
+  /**
+   * Additional data for merely for use with the frontend. Has no functional effect.
+   */
+  metadata?: any;
 }
 
 export interface StopAction {


### PR DESCRIPTION
Service calls can have additional metadata stored with them for the frontend.
We need to allow for that. We don't have to care about its contents (the backend doesn't either).

This was added some releases back, but the extension didn't add support for it yet.

fixes #2120