### PR TITLE
remove deprecated 'send_if_off'

### DIFF
--- a/src/language-service/src/schemas/integrations/core/mqtt.ts
+++ b/src/language-service/src/schemas/integrations/core/mqtt.ts
@@ -789,12 +789,6 @@ export interface ClimateItem extends BaseItem {
   retain?: boolean;
 
   /**
-   * Set to false to suppress sending of all MQTT messages when the current mode is Off.
-   * https://www.home-assistant.io/integrations/climate.mqtt/#send_if_off
-   */
-  send_if_off: boolean;
-
-  /**
    * A template to render the value sent to the swing_mode_command_topic with.
    * https://www.home-assistant.io/integrations/climate.mqtt/#swing_mode_command_template
    */


### PR DESCRIPTION
The 'send_if_off' option is deprecated
https://github.com/home-assistant/core/pull/66062
https://github.com/home-assistant/core/pull/66062/files#diff-c8ebf96494fa4dca0f6c463949933572a837d982d5d9fbd8f042173bba03fbd1


Leaving this as a required item, would cause a validation error.