### PR TITLE
Ensure old-style platform MQTT configuration is marked invalid

### DIFF
--- a/src/language-service/src/schemas/integrations/core/alarm_control_panel.ts
+++ b/src/language-service/src/schemas/integrations/core/alarm_control_panel.ts
@@ -15,7 +15,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!(template)$)\w+$
+   * @TJS-pattern ^(?!(template|mqtt)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/core/binary_sensor.ts
+++ b/src/language-service/src/schemas/integrations/core/binary_sensor.ts
@@ -18,7 +18,7 @@ export type File = Item | Item[];
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!(group|template|tod)$)\w+$
+   * @TJS-pattern ^(?!(group|template|tod|mqtt)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/core/camera.ts
+++ b/src/language-service/src/schemas/integrations/core/camera.ts
@@ -14,7 +14,6 @@ export type File = Item | Item[];
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface OtherPlatform extends PlatformSchema {
-
   /**
    * @TJS-pattern ^(?!(mqtt)$)\w+$
    */

--- a/src/language-service/src/schemas/integrations/core/camera.ts
+++ b/src/language-service/src/schemas/integrations/core/camera.ts
@@ -14,6 +14,10 @@ export type File = Item | Item[];
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface OtherPlatform extends PlatformSchema {
+
+  /**
+   * @TJS-pattern ^(?!(mqtt)$)\w+$
+   */
   platform: string;
 }
 

--- a/src/language-service/src/schemas/integrations/core/climate.ts
+++ b/src/language-service/src/schemas/integrations/core/climate.ts
@@ -14,7 +14,6 @@ export type File = Item | Item[];
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface OtherPlatform extends PlatformSchema {
-
   /**
    * @TJS-pattern ^(?!(mqtt)$)\w+$
    */

--- a/src/language-service/src/schemas/integrations/core/climate.ts
+++ b/src/language-service/src/schemas/integrations/core/climate.ts
@@ -14,6 +14,10 @@ export type File = Item | Item[];
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface OtherPlatform extends PlatformSchema {
+
+  /**
+   * @TJS-pattern ^(?!(mqtt)$)\w+$
+   */
   platform: string;
 }
 

--- a/src/language-service/src/schemas/integrations/core/device_tracker.ts
+++ b/src/language-service/src/schemas/integrations/core/device_tracker.ts
@@ -14,7 +14,6 @@ export type File = Item | Item[];
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface OtherPlatform extends PlatformSchema {
-
   /**
    * @TJS-pattern ^(?!(mqtt)$)\w+$
    */

--- a/src/language-service/src/schemas/integrations/core/device_tracker.ts
+++ b/src/language-service/src/schemas/integrations/core/device_tracker.ts
@@ -14,6 +14,10 @@ export type File = Item | Item[];
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface OtherPlatform extends PlatformSchema {
+
+  /**
+   * @TJS-pattern ^(?!(mqtt)$)\w+$
+   */
   platform: string;
 }
 

--- a/src/language-service/src/schemas/integrations/core/fan.ts
+++ b/src/language-service/src/schemas/integrations/core/fan.ts
@@ -15,7 +15,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!(template)$)\w+$
+   * @TJS-pattern ^(?!(template|mqtt)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/core/light.ts
+++ b/src/language-service/src/schemas/integrations/core/light.ts
@@ -16,7 +16,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!(group|template)$)\w+$
+   * @TJS-pattern ^(?!(group|template|mqtt)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/core/lock.ts
+++ b/src/language-service/src/schemas/integrations/core/lock.ts
@@ -15,7 +15,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!(template)$)\w+$
+   * @TJS-pattern ^(?!(template|mqtt)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/core/number.ts
+++ b/src/language-service/src/schemas/integrations/core/number.ts
@@ -13,6 +13,9 @@ export type File = Item | Item[];
  * @TJS-additionalProperties true
  */
 interface OtherPlatform extends PlatformSchema {
+  /**
+   * @TJS-pattern ^(?!(mqtt)$)\w+$
+   */
   platform: string;
 }
 

--- a/src/language-service/src/schemas/integrations/core/select.ts
+++ b/src/language-service/src/schemas/integrations/core/select.ts
@@ -13,6 +13,9 @@ export type File = Item | Item[];
  * @TJS-additionalProperties true
  */
 interface OtherPlatform extends PlatformSchema {
+  /**
+   * @TJS-pattern ^(?!(mqtt)$)\w+$
+   */
   platform: string;
 }
 

--- a/src/language-service/src/schemas/integrations/core/sensor.ts
+++ b/src/language-service/src/schemas/integrations/core/sensor.ts
@@ -17,7 +17,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!(mqtt_room|template|uptime)$)\w+$
+   * @TJS-pattern ^(?!(mqtt_room|template|uptime|mqtt)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/core/switch.ts
+++ b/src/language-service/src/schemas/integrations/core/switch.ts
@@ -15,7 +15,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!(template)$)\w+$
+   * @TJS-pattern ^(?!(template|mqtt)$)\w+$
    */
   platform: string;
 }

--- a/src/language-service/src/schemas/integrations/core/vacuum.ts
+++ b/src/language-service/src/schemas/integrations/core/vacuum.ts
@@ -15,7 +15,7 @@ export type File = Item | Item[];
  */
 interface OtherPlatform extends PlatformSchema {
   /**
-   * @TJS-pattern ^(?!(template)$)\w+$
+   * @TJS-pattern ^(?!(template|mqtt)$)\w+$
    */
   platform: string;
 }


### PR DESCRIPTION
Ensure old-style MQTT platform configuration is marked as invalid.

Done this, by not matching it to "OtherPlatform", resulting in no valid schema could be found: thus invalid.