### PR TITLE
Update list of supported sensor device classes

### DIFF
--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -86,18 +86,23 @@ export type DeviceClassesMediaPlayer = "tv" | "speaker" | "receiver";
 export type DeviceClassesSensor =
   | "apparent_power"
   | "aqi"
+  | "atmospheric_pressure"
   | "battery"
   | "carbon_dioxide"
   | "carbon_monoxide"
   | "current"
+  | "data_rate"
+  | "data_size"
   | "date"
   | "distance"
   | "duration"
   | "energy"
+  | "enum"
   | "frequency"
   | "gas"
   | "humidity"
   | "illuminance"
+  | "irradiance"
   | "moisture"
   | "monetary"
   | "nitrogen_dioxide"
@@ -109,9 +114,12 @@ export type DeviceClassesSensor =
   | "pm25"
   | "power_factor"
   | "power"
+  | "precipitation_intensity"
+  | "precipitation"
   | "pressure"
   | "reactive_power"
   | "signal_strength"
+  | "sound_pressure"
   | "sulphur_dioxide"
   | "temperature"
   | "timestamp"
@@ -119,7 +127,8 @@ export type DeviceClassesSensor =
   | "voltage"
   | "volume"
   | "water"
-  | "weight";
+  | "weight"
+  | "wind_speed";
 
 export type EntityCategory = "config" | "diagnostic";
 


### PR DESCRIPTION
Extends the list of supported sensor device classes, in sync with Home Assistant Core 2023.1.0b1

