### PR TITLE
fix mqtt schema [device]/identifiers] unknown

### DIFF
--- a/src/language-service/src/schemas/integrations/core/mqtt.ts
+++ b/src/language-service/src/schemas/integrations/core/mqtt.ts
@@ -345,7 +345,7 @@ interface BaseItem {
     /**
      * A list of IDs that uniquely identify the device. For example a serial number.
      */
-    identifier?: string;
+    identifiers?: string | string[];
 
     /**
      * The manufacturer of the device.


### PR DESCRIPTION
fix naming device/identifier to identifiers and add the alternative type of string[]