### PR TITLE
Add input_button to input reload domains

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -269,6 +269,7 @@ export async function activate(
   });
 
   const inputReloadDomains = [
+    "input_button",
     "input_boolean",
     "input_datetime",
     "input_number",


### PR DESCRIPTION
Seems like `input_button` was missed in the list of input reloads.