### PR TITLE
Update @types/node to fix schema generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@types/mocha": "10.0.1",
-        "@types/node": "16.4.10",
+        "@types/node": "16.18.31",
         "@types/request": "2.48.8",
         "@types/vscode": "1.45.1",
         "@types/ws": "8.5.4",
@@ -345,9 +345,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.4.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
-      "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ==",
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==",
       "dev": true
     },
     "node_modules/@types/request": {
@@ -3923,12 +3923,6 @@
         "typescript-json-schema": "bin/typescript-json-schema"
       }
     },
-    "node_modules/typescript-json-schema/node_modules/@types/node": {
-      "version": "16.10.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.4.tgz",
-      "integrity": "sha512-EITwVTX5B4nDjXjGeQAfXOrm+Jn+qNjDmyDRtWoD+wZsl/RDPRTFRKivs4Mt74iOFlLOrE5+Kf+p5yjyhm3+cA==",
-      "dev": true
-    },
     "node_modules/typescript-json-schema/node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -4713,9 +4707,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.4.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
-      "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ==",
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==",
       "dev": true
     },
     "@types/request": {
@@ -7326,12 +7320,6 @@
         "yargs": "^17.1.1"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "16.10.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.4.tgz",
-          "integrity": "sha512-EITwVTX5B4nDjXjGeQAfXOrm+Jn+qNjDmyDRtWoD+wZsl/RDPRTFRKivs4Mt74iOFlLOrE5+Kf+p5yjyhm3+cA==",
-          "dev": true
-        },
         "glob": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -427,7 +427,7 @@
   },
   "devDependencies": {
     "@types/mocha": "10.0.1",
-    "@types/node": "16.4.10",
+    "@types/node": "16.18.31",
     "@types/request": "2.48.8",
     "@types/vscode": "1.45.1",
     "@types/ws": "8.5.4",

--- a/src/language-service/src/schemas/generateSchemas.ts
+++ b/src/language-service/src/schemas/generateSchemas.ts
@@ -3,6 +3,7 @@ import * as TJS from "typescript-json-schema";
 import * as fs from "fs";
 import * as path from "path";
 import { PathToSchemaMapping } from "./schemaService";
+import { exit } from "process";
 
 const settings: TJS.PartialArgs = {
   required: true,
@@ -36,6 +37,10 @@ if (fs.readdirSync(outputFolder).length > 0 && process.argv[2] === "--quick") {
       compilerOptions
     );
     const schema = TJS.generateSchema(program, mapping.fromType, settings);
+    if (schema === null) {
+      console.error("Schema generation failed");
+      exit(1);
+    }
     fs.writeFileSync(
       path.join(outputFolder, mapping.file),
       JSON.stringify(schema)

--- a/src/server/fileAccessor.ts
+++ b/src/server/fileAccessor.ts
@@ -42,7 +42,7 @@ export class VsCodeFileAccessor implements FileAccessor {
         if (!exists) {
           c(null);
         }
-        fs.readFile(uri, "UTF-8", (err, result) => {
+        fs.readFile(uri, "utf-8", (err, result) => {
           if (err) {
             e(err);
           } else {


### PR DESCRIPTION
An update to `typescript-json-schema` updated the node types that were being used, causing type generation to fail. This resulted in all the schema files containing `null`, which would then manifest in the error `Unable to load schema`.

1. Update `@types/node` to a common version, fixing this issue
2. Add an error log and exit if this issue was to happen again
3. Update the typing for reading files to `utf-8` to satisfy the new types

Validation - Installed a newer version of the add-on in my VS Code container and the error message about schema went away and I was able to get validation for a binary sensor type. I don't have a ton of experience with VS Code add-ons but this was a scenario that wasn't working before and I do have a decent amount of experience with JavaScript build tools and TypeScript.

fixes #2602 