### PR TITLE
add action to template schema

### DIFF
--- a/src/language-service/src/schemas/integrations/core/template.ts
+++ b/src/language-service/src/schemas/integrations/core/template.ts
@@ -59,7 +59,7 @@ export interface Item {
   sensor?: SensorItem[] | IncludeList;
 
   /**
-   * Define actions to be executed when the trigger fires. Optional. Variables set by the action script are available when evaluating entity templates. 
+   * Define actions to be executed when the trigger fires. Optional. Variables set by the action script are available when evaluating entity templates.
    * This can be used to interact with anything via services, in particular services with response data. See action documentation.
    * https://www.home-assistant.io/integrations/template/#action
    */

--- a/src/language-service/src/schemas/integrations/core/template.ts
+++ b/src/language-service/src/schemas/integrations/core/template.ts
@@ -59,6 +59,13 @@ export interface Item {
   sensor?: SensorItem[] | IncludeList;
 
   /**
+   * Define actions to be executed when the trigger fires. Optional. Variables set by the action script are available when evaluating entity templates. 
+   * This can be used to interact with anything via services, in particular services with response data. See action documentation.
+   * https://www.home-assistant.io/integrations/template/#action
+   */
+  action?: Action | Action[];
+
+  /**
    * Define an automation trigger to update the entities. Optional. If omitted will update based on referenced entities. See trigger documentation.
    * https://www.home-assistant.io/integrations/template#trigger
    */


### PR DESCRIPTION
As introduced in HA 2023.9

"Trigger template entities can now have an action block that is executed after the trigger but before the entities are rendered."

https://www.home-assistant.io/blog/2023/09/06/release-20239/#actions-for-trigger-template-entities