### PR TITLE
Fix supported features in entity selector filter

### DIFF
--- a/src/language-service/src/schemas/integrations/core/alarm_control_panel.ts
+++ b/src/language-service/src/schemas/integrations/core/alarm_control_panel.ts
@@ -21,3 +21,11 @@ interface OtherPlatform extends PlatformSchema {
 }
 
 type Item = TemplatePlatformSchema | OtherPlatform;
+
+export type SupportedFeature =
+  | "camera.AlarmControlPanelEntityFeature.ARM_HOME"
+  | "camera.AlarmControlPanelEntityFeature.ARM_AWAY"
+  | "camera.AlarmControlPanelEntityFeature.ARM_NIGHT"
+  | "camera.AlarmControlPanelEntityFeature.TRIGGER"
+  | "camera.AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS"
+  | "camera.AlarmControlPanelEntityFeature.ARM_VACATION";

--- a/src/language-service/src/schemas/integrations/core/camera.ts
+++ b/src/language-service/src/schemas/integrations/core/camera.ts
@@ -21,3 +21,7 @@ interface OtherPlatform extends PlatformSchema {
 }
 
 type Item = OtherPlatform;
+
+export type SupportedFeature =
+  | "camera.CameraEntityFeature.ON_OFF"
+  | "camera.CameraEntityFeature.STREAM";

--- a/src/language-service/src/schemas/integrations/core/climate.ts
+++ b/src/language-service/src/schemas/integrations/core/climate.ts
@@ -21,3 +21,12 @@ interface OtherPlatform extends PlatformSchema {
 }
 
 type Item = OtherPlatform;
+
+export type SupportedFeature =
+  | "climate.ClimateEntityFeature.TARGET_TEMPERATURE"
+  | "climate.ClimateEntityFeature.TARGET_TEMPERATURE_RANGE"
+  | "climate.ClimateEntityFeature.TARGET_HUMIDITY"
+  | "climate.ClimateEntityFeature.FAN_MODE"
+  | "climate.ClimateEntityFeature.PRESET_MODE"
+  | "climate.ClimateEntityFeature.SWING_MODE"
+  | "climate.ClimateEntityFeature.AUX_HEAT";

--- a/src/language-service/src/schemas/integrations/core/cover.ts
+++ b/src/language-service/src/schemas/integrations/core/cover.ts
@@ -21,3 +21,13 @@ interface OtherPlatform extends PlatformSchema {
 }
 
 type Item = TemplatePlatformSchema | OtherPlatform;
+
+export type SupportedFeature =
+  | "cover.CoverEntityFeature.OPEN"
+  | "cover.CoverEntityFeature.CLOSE"
+  | "cover.CoverEntityFeature.SET_POSITION"
+  | "cover.CoverEntityFeature.STOP"
+  | "cover.CoverEntityFeature.OPEN_TILT"
+  | "cover.CoverEntityFeature.CLOSE_TILT"
+  | "cover.CoverEntityFeature.STOP_TILT"
+  | "cover.CoverEntityFeature.SET_TILT_POSITION";

--- a/src/language-service/src/schemas/integrations/core/fan.ts
+++ b/src/language-service/src/schemas/integrations/core/fan.ts
@@ -21,3 +21,9 @@ interface OtherPlatform extends PlatformSchema {
 }
 
 type Item = TemplatePlatformSchema | OtherPlatform;
+
+export type SupportedFeature =
+  | "fan.FanEntityFeature.SET_SPEED"
+  | "fan.FanEntityFeature.OSCILLATE"
+  | "fan.FanEntityFeature.DIRECTION"
+  | "fan.FanEntityFeature.PRESET_MODE";

--- a/src/language-service/src/schemas/integrations/core/light.ts
+++ b/src/language-service/src/schemas/integrations/core/light.ts
@@ -22,3 +22,8 @@ interface OtherPlatform extends PlatformSchema {
 }
 
 type Item = GroupPlatformSchema | TemplatePlatformSchema | OtherPlatform;
+
+export type SupportedFeature =
+  | "light.LightEntityFeature.EFFECT"
+  | "light.LightEntityFeature.FLASH"
+  | "light.LightEntityFeature.TRANSITION";

--- a/src/language-service/src/schemas/integrations/core/lock.ts
+++ b/src/language-service/src/schemas/integrations/core/lock.ts
@@ -21,3 +21,5 @@ interface OtherPlatform extends PlatformSchema {
 }
 
 type Item = TemplatePlatformSchema | OtherPlatform;
+
+export type SupportedFeature = "lock.LockEntityFeature.OPEN";

--- a/src/language-service/src/schemas/integrations/core/update.ts
+++ b/src/language-service/src/schemas/integrations/core/update.ts
@@ -1,0 +1,12 @@
+/**
+ * Update integration
+ * Source: https://github.com/home-assistant/core/blob/dev/homeassistant/components/update/__init__.py
+ */
+
+export type Domain = "update";
+export type SupportedFeature =
+  | "update.UpdateEntityFeature.INSTALL"
+  | "update.UpdateEntityFeature.SPECIFIC_VERSION"
+  | "update.UpdateEntityFeature.PROGRESS"
+  | "update.UpdateEntityFeature.BACKUP"
+  | "update.UpdateEntityFeature.RELEASE_NOTES";

--- a/src/language-service/src/schemas/integrations/core/vacuum.ts
+++ b/src/language-service/src/schemas/integrations/core/vacuum.ts
@@ -21,3 +21,19 @@ interface OtherPlatform extends PlatformSchema {
 }
 
 type Item = TemplatePlatformSchema | OtherPlatform;
+
+export type SupportedFeature =
+  | "vacuum.VacuumEntityFeature.TURN_ON"
+  | "vacuum.VacuumEntityFeature.TURN_OFF"
+  | "vacuum.VacuumEntityFeature.PAUSE"
+  | "vacuum.VacuumEntityFeature.STOP"
+  | "vacuum.VacuumEntityFeature.RETURN_HOME"
+  | "vacuum.VacuumEntityFeature.FAN_SPEED"
+  | "vacuum.VacuumEntityFeature.BATTERY"
+  | "vacuum.VacuumEntityFeature.STATUS"
+  | "vacuum.VacuumEntityFeature.SEND_COMMAND"
+  | "vacuum.VacuumEntityFeature.LOCATE"
+  | "vacuum.VacuumEntityFeature.CLEAN_SPOT"
+  | "vacuum.VacuumEntityFeature.MAP"
+  | "vacuum.VacuumEntityFeature.STATE"
+  | "vacuum.VacuumEntityFeature.START";

--- a/src/language-service/src/schemas/integrations/core/weather.ts
+++ b/src/language-service/src/schemas/integrations/core/weather.ts
@@ -21,3 +21,8 @@ interface OtherPlatform extends PlatformSchema {
 }
 
 type Item = TemplatePlatformSchema | OtherPlatform;
+
+export type SupportedFeature =
+  | "weather.WeatherEntityFeature.FORECAST_DAILY"
+  | "weather.WeatherEntityFeature.FORECAST_HOURLY"
+  | "weather.WeatherEntityFeature.FORECAST_TWICE_DAILY";

--- a/src/language-service/src/schemas/integrations/selectors.ts
+++ b/src/language-service/src/schemas/integrations/selectors.ts
@@ -8,6 +8,7 @@ import {
   Entity,
   PositiveInteger,
   Deprecated,
+  SupportedFeature,
 } from "../types";
 
 export type Selector =
@@ -265,7 +266,7 @@ interface EntitySelectorFilter {
    * Limits the list of entities to entities that have a certain supported feature.
    * https://www.home-assistant.io/docs/blueprint/selectors/#entity-selector
    */
-  supported_features?: number | number[];
+  supported_features?: SupportedFeature | SupportedFeature[];
 }
 
 export interface EntitySelector {

--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -1,3 +1,14 @@
+import { SupportedFeature as SupportedFeatureAlarmControlPanel } from "./integrations/core/alarm_control_panel";
+import { SupportedFeature as SupportedFeatureCamera } from "./integrations/core/camera";
+import { SupportedFeature as SupportedFeatureClimate } from "./integrations/core/climate";
+import { SupportedFeature as SupportedFeatureCover } from "./integrations/core/cover";
+import { SupportedFeature as SupportedFeatureFan } from "./integrations/core/fan";
+import { SupportedFeature as SupportedFeatureLight } from "./integrations/core/light";
+import { SupportedFeature as SupportedFeatureLock } from "./integrations/core/lock";
+import { SupportedFeature as SupportedFeatureUpdate } from "./integrations/core/update";
+import { SupportedFeature as SupportedFeatureVacuum } from "./integrations/core/vacuum";
+import { SupportedFeature as SupportedFeatureWeather } from "./integrations/core/weather";
+
 export type Area = string;
 
 export type ColorMode =
@@ -1556,3 +1567,15 @@ export type PrecipitationUnit =
   | "mm"
   | "in"
   | "yd";
+
+export type SupportedFeature =
+  | SupportedFeatureAlarmControlPanel
+  | SupportedFeatureCamera
+  | SupportedFeatureClimate
+  | SupportedFeatureCover
+  | SupportedFeatureFan
+  | SupportedFeatureLight
+  | SupportedFeatureLock
+  | SupportedFeatureUpdate
+  | SupportedFeatureVacuum
+  | SupportedFeatureWeather;


### PR DESCRIPTION
I was creating a blueprint that required a specific supported feature of the entity.
The suggested value of a number is not valid in this case.

<img width="785" alt="2023-10-07_18-24-55" src="https://github.com/keesschollaart81/vscode-home-assistant/assets/15093472/30ec37dd-a87d-43cc-8c70-5c3a4c619b31">

Since I also wanted this specifically for update entities, I had to create a `update.ts` file for that domain as it was missing.