### PR TITLE
Introduce new entityIds keyword alias "group_members"

### DIFF
--- a/src/language-service/src/completionHelpers/entityIds.ts
+++ b/src/language-service/src/completionHelpers/entityIds.ts
@@ -23,6 +23,7 @@ export class EntityIdCompletionContribution implements JSONWorkerContribution {
     "scene",
     "zone",
     "zones",
+    "group_members"
   ];
 
   constructor(private haConnection: IHaConnection) {}


### PR DESCRIPTION
service: media_player.join has a property group_members that receives a list of entityIds.