### PR TITLE
Fix calendar initial_view: "list" > "listWeek"

### DIFF
--- a/src/language-service/src/schemas/lovelace/cards/calendar.ts
+++ b/src/language-service/src/schemas/lovelace/cards/calendar.ts
@@ -25,7 +25,7 @@ export interface Schema {
    * The view that will show first when the card is loaded onto the page.
    * https://www.home-assistant.io/lovelace/calendar/#initial_view
    */
-  initial_view?: "dayGridMonth" | "dayGridWeek" | "dayGridDay" | "list";
+  initial_view?: "dayGridMonth" | "dayGridWeek" | "dayGridDay" | "listWeek";
 
   /**
    * The card theme, which may be set to any theme from the themes.yaml file.


### PR DESCRIPTION
I noticed that it's expecting a "list", not "listWeek" as mentioned in the docs.

Ref to docs: https://www.home-assistant.io/dashboards/calendar/#initial_view

![image](https://github.com/keesschollaart81/vscode-home-assistant/assets/3549445/00eb10a5-fc08-4812-9b53-9c3b316fd03d)

![image](https://github.com/keesschollaart81/vscode-home-assistant/assets/3549445/9a982f7d-0f36-4869-bae2-523b43a94ee2)
