### PR TITLE
Fix weather template temperature unit

### DIFF
--- a/src/language-service/src/schemas/integrations/core/homeassistant.ts
+++ b/src/language-service/src/schemas/integrations/core/homeassistant.ts
@@ -7,7 +7,6 @@ import {
   IncludeNamed,
   Integer,
   LanguageTags,
-  TemperatureUnit,
   TimeZone,
   UnitSystem,
 } from "../../types";
@@ -144,7 +143,7 @@ export interface Schema {
    * "C" for Celsius, "F" for Fahrenheit.
    * https://www.home-assistant.io/docs/configuration/basic/#temperature_unit
    */
-  temperature_unit?: TemperatureUnit;
+  temperature_unit?: "C" | "F";
 }
 
 interface CoreCustomize {

--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -1530,7 +1530,7 @@ export type TimeZone =
   | "Zulu";
 
 export type UnitSystem = "metric" | "imperial";
-export type TemperatureUnit = "C" | "F";
+export type TemperatureUnit = "°C" | "°F" | "K";
 export type PressureUnit =
   | "Pa"
   | "hPa"


### PR DESCRIPTION
Addresses: https://github.com/hassio-addons/addon-vscode/issues/870

Small workaround, as the core configuration does need `F` or `C`.