### PR TITLE
Auto-discover Home Assistant when running inside an add-on

### DIFF
--- a/src/language-service/src/configuration.ts
+++ b/src/language-service/src/configuration.ts
@@ -54,6 +54,10 @@ export class ConfigurationService implements IConfigurationService {
     if (!this.token && process.env.HASS_TOKEN) {
       this.token = process.env.HASS_TOKEN;
     }
+    if (!this.url && !this.token && process.env.SUPERVISOR_TOKEN) {
+      this.url = this.getUri("http://supervisor/core");
+      this.token = process.env.SUPERVISOR_TOKEN;
+    }
   }
 
   private getUri = (value: string): string => {


### PR DESCRIPTION
Add-ons have `SUPERVISOR_TOKEN` set as environment variable (for example _Terminal add-on_ when running from VS Code Remote SSH. But even the regular VS Code add-on should have it.