### PR TITLE
Fix schema resolution using Samba share on Windows

### DIFF
--- a/src/language-service/src/schemas/schemaService.ts
+++ b/src/language-service/src/schemas/schemaService.ts
@@ -60,7 +60,7 @@ export class SchemaServiceForIncludes {
       if (relatedPathToSchemaMapping) {
         const id = `http://schemas.home-assistant.io/${relatedPathToSchemaMapping.key}`;
         let absolutePath = fs.realpathSync.native(haFiles[sourceFile].filename);
-        absolutePath = absolutePath.replace("\\", "/");
+        absolutePath = absolutePath.replaceAll("\\", "/");
         const fileass = encodeURI(absolutePath);
         let resultEntry = results.find((x) => x.uri === id);
 

--- a/src/language-service/src/schemas/schemaService.ts
+++ b/src/language-service/src/schemas/schemaService.ts
@@ -60,7 +60,7 @@ export class SchemaServiceForIncludes {
       if (relatedPathToSchemaMapping) {
         const id = `http://schemas.home-assistant.io/${relatedPathToSchemaMapping.key}`;
         let absolutePath = fs.realpathSync.native(haFiles[sourceFile].filename);
-        absolutePath = absolutePath.replaceAll("\\", "/");
+        absolutePath = absolutePath.replace(new RegExp("\\", "g"), "/");
         const fileass = encodeURI(absolutePath);
         let resultEntry = results.find((x) => x.uri === id);
 


### PR DESCRIPTION
Hello!

While using this extension via the Samba share addon on Windows I noticed that the schemas were not working properly, in the logs I noticed that only the first backslash was being replaced and this was triggering the issue in the schema resolution of `yaml-language-server`:

```
Applying schemas to 10 of your configuration files...
Assigning /%5C192.168.1.102%5Cconfig%5Cconfiguration.yaml the configuration.yaml schema
Assigning /%5C192.168.1.102%5Cconfig%5Cautomations.yaml the configuration.yaml/automation schema
Assigning /%5C192.168.1.102%5Cconfig%5Cautomations.yaml the configuration.yaml/automation schema
Assigning /%5C192.168.1.102%5Cconfig%5Cscripts.yaml the configuration.yaml/script schema
Assigning /%5C192.168.1.102%5Cconfig%5Cscenes.yaml the configuration.yaml/scene schema
Assigning /%5C192.168.1.102%5Cconfig%5Cbinary_sensor.yaml the configuration.yaml/binary_sensor schema
Schemas updated!
```

I also saw this [comment](https://github.com/keesschollaart81/vscode-home-assistant/issues/1002#issuecomment-881968808) from someone that had a similar issue. After this change the entry is registered properly and the schemas work:

```
Applying schemas to 10 of your configuration files...
Assigning //192.168.1.102/config/configuration.yaml the configuration.yaml schema
Assigning //192.168.1.102/config/automations.yaml the configuration.yaml/automation schema
Assigning //192.168.1.102/config/automations.yaml the configuration.yaml/automation schema
Assigning //192.168.1.102/config/scripts.yaml the configuration.yaml/script schema
Assigning //192.168.1.102/config/scenes.yaml the configuration.yaml/scene schema
Assigning //192.168.1.102/config/binary_sensor.yaml the configuration.yaml/binary_sensor schema
Schemas updated!
```
