### PR TITLE
Fix yaml discovery for Samba share and Windows

### DIFF
--- a/src/language-service/src/haConfig/haConfig.ts
+++ b/src/language-service/src/haConfig/haConfig.ts
@@ -106,10 +106,10 @@ export class HomeAssistantConfiguration {
       "automations.yaml",
     ];
     const ourFolders = [
-      "blueprints/automation/",
-      "blueprints/script/",
-      "automations/",
-      "custom_sentences/",
+      path.join("blueprints", "automation") + path.sep,
+      path.join("blueprints", "script") + path.sep,
+      "automations" + path.sep,
+      "custom_sentences" + path.sep,
     ];
 
     const rootFiles = ourFiles.filter((f) => filesInRoot.some((y) => y === f));
@@ -125,7 +125,7 @@ export class HomeAssistantConfiguration {
       if (areOurFilesSomehwere.length > 0) {
         this.subFolder = areOurFilesSomehwere[0].substr(
           0,
-          areOurFilesSomehwere[0].lastIndexOf("/"),
+          areOurFilesSomehwere[0].lastIndexOf(path.sep),
         );
         return areOurFilesSomehwere;
       }
@@ -157,22 +157,22 @@ export class HomeAssistantConfiguration {
   private discoverCore = async (
     filename: string,
     // eslint-disable-next-line no-shadow, @typescript-eslint/no-shadow
-    path: string,
+    dirPath: string,
     files: FilesCollection,
   ): Promise<FilesCollection> => {
-    if (path.startsWith("/")) {
-      path = path.substring(1);
+    if (dirPath.startsWith(path.sep)) {
+      dirPath = dirPath.substring(1);
     }
 
     const homeAssistantYamlFile = new HomeAssistantYamlFile(
       this.fileAccessor,
       filename,
-      path,
+      dirPath,
     );
     files[filename] = homeAssistantYamlFile;
 
     let error = false;
-    let errorMessage = `File '${filename}' could not be parsed, it was referenced from path '${path}'.This file will be ignored.`;
+    let errorMessage = `File '${filename}' could not be parsed, it was referenced from path '${dirPath}'.This file will be ignored.`;
     let includes: IncludeReferences = {};
     try {
       includes = await homeAssistantYamlFile.getIncludes();
@@ -194,7 +194,7 @@ export class HomeAssistantConfiguration {
     }
 
     if (error) {
-      if (filename === path) {
+      if (filename === dirPath) {
         // root file has more impact
         console.warn(errorMessage);
       } else {

--- a/src/language-service/src/schemas/schemaService.ts
+++ b/src/language-service/src/schemas/schemaService.ts
@@ -27,30 +27,30 @@ export class SchemaServiceForIncludes {
 
     for (const [sourceFile, sourceFileMapping] of haFiles.entries()) {
       let sourceFileMappingPath = sourceFileMapping.path.replace(
-        "homeassistant/packages/",
+        path.join("homeassistant", "packages") + path.sep,
         "",
       );
       sourceFileMappingPath = sourceFileMappingPath.replace(
-        /cards\/cards/g,
+        /cards(\/|\\)cards/g,
         "cards",
       );
 
-      if (sourceFileMappingPath.startsWith("blueprints/automation/")) {
+      if (sourceFileMappingPath.startsWith(path.join("blueprints", "automation") + path.sep)) {
         sourceFileMappingPath = "blueprints/automation";
       }
 
-      if (sourceFileMappingPath.startsWith("blueprints/script/")) {
+      if (sourceFileMappingPath.startsWith(path.join("blueprints", "script") + path.sep)) {
         sourceFileMappingPath = "blueprints/script";
       }
 
       if (
-        sourceFileMappingPath.startsWith("automations/") ||
+        sourceFileMappingPath.startsWith("automations" + path.sep) ||
         sourceFileMappingPath === "automations.yaml"
       ) {
         sourceFileMappingPath = "configuration.yaml/automation";
       }
 
-      if (sourceFileMappingPath.startsWith("custom_sentences/")) {
+      if (sourceFileMappingPath.startsWith("custom_sentences" + path.sep)) {
         sourceFileMappingPath = "custom_sentences.yaml";
       }
 


### PR DESCRIPTION
This is an issue with the path separator when using Windows as is handled using backslash (`\`) instead of forwardslash (`/`) used in Linux and macOS.

The change was to use `path.sep` and `path.join` to properly handle the OS native path separator and the concatenation of paths properly.