### PR TITLE
Update schema for template vacuums

### DIFF
--- a/src/language-service/src/schemas/integrations/core/template.ts
+++ b/src/language-service/src/schemas/integrations/core/template.ts
@@ -1198,7 +1198,7 @@ interface VacuumPlatformItem {
    * Defines templates for attributes of the sensor.
    * https://www.home-assistant.io/integrations/vacuum.template#attribute_templates
    */
-  attributes_template?: { [key: string]: Template };
+  attribute_templates?: { [key: string]: Template };
 
   /**
    * Defines a template to get the available state of the component. If the template returns true, the device is available.


### PR DESCRIPTION
Template vacuums' `attribute_templates` is wrong in schema, is currently `attributes_template`. Update to match documentation (correctly linked in schema to https://www.home-assistant.io/integrations/vacuum.template#attribute_templates, but mis-named in schema).