### PR TITLE
Add condition support to trigger based templates

### DIFF
--- a/src/language-service/src/schemas/integrations/core/template.ts
+++ b/src/language-service/src/schemas/integrations/core/template.ts
@@ -6,6 +6,7 @@ import {
   DeviceClassesBinarySensor,
   DeviceClassesCover,
   DeviceClassesSensor,
+  DynamicTemplate,
   IncludeList,
   IncludeNamed,
   PositiveInteger,
@@ -18,6 +19,7 @@ import {
   WindSpeedUnit,
 } from "../../types";
 import { Action } from "../actions";
+import { Condition } from "../conditions";
 import { PlatformSchema } from "../platform";
 import { Trigger } from "../triggers";
 
@@ -70,6 +72,12 @@ export interface Item {
    * https://www.home-assistant.io/integrations/template/#action
    */
   action?: Action | Action[];
+
+  /**
+   * Define conditions that have to be met after a trigger fires and before any actions are executed or sensor updates are performed (for trigger-based entities only). Optional. See condition documentation.
+   * https://www.home-assistant.io/integrations/template/#condition
+   */
+  condition?: Condition | Condition[] | DynamicTemplate | IncludeList;
 
   /**
    * Define an automation trigger to update the entities. Optional. If omitted will update based on referenced entities. See trigger documentation.


### PR DESCRIPTION
HA 2024.10 added support for conditions on trigger based templates. Currently an error saying `Property condition is not allowed.`

![image](https://github.com/user-attachments/assets/9957ac92-0a13-4acd-a3cd-78d10c7c2e24)

This PR adds support for the condition key.

Note, I failed to run the local development environment, so I haven't been able to test this change.

Should also fix the issue in the HA vscode addon https://github.com/hassio-addons/addon-vscode/issues/891