### PR TITLE
Optimize schema generation in compile script

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,7 +412,7 @@
     ]
   },
   "scripts": {
-    "compile": "ts-node src/language-service/src/schemas/generateSchemas.ts --quick && tsc -p ./ ",
+    "compile": "tsc -p src/language-service/tsconfig.json && node src/language-service/dist/schemas/generateSchemas.js --quick && tsc -p ./ ",
     "format:eslint": "eslint \"**/src/**/*.ts\" --fix",
     "format:prettier": "prettier \"**/src/**/*.json\" --write",
     "format": "npm run format:eslint && npm run format:prettier",

--- a/src/language-service/tsconfig.json
+++ b/src/language-service/tsconfig.json
@@ -10,7 +10,6 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "declaration": true,
-    "noEmit": true,
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "noImplicitReturns": true,


### PR DESCRIPTION
Replaces ts-node with tsc compilation for the schema generation
step, improving build consistency and performance.