### PR TITLE
Upgrade yaml-language-server to 1.18.0 and yaml to 2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.43.0",
       "license": "MIT",
       "dependencies": {
+        "@vscode/extension-telemetry": "^1.0.0",
         "axios": "^1.9.0",
         "bufferutil": "^4.0.9",
         "home-assistant-js-websocket": "^9.5.0",
         "utf-8-validate": "^6.0.5",
-        "vscode-extension-telemetry": "0.4.5",
         "vscode-json-languageservice": "4.1.0",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver": "^9.0.1",
@@ -460,6 +460,120 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@microsoft/1ds-core-js": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.3.8.tgz",
+      "integrity": "sha512-5y7pmcqoYmh+461xyUog4aQAZ2ZIoYlAg7VkHU0G+dpOwAmwN3WECnsO/8RNagNiVwsFOBeN5e2OxKm3vruJWw==",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.3.8",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/1ds-post-js": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.3.8.tgz",
+      "integrity": "sha512-9Jq6PqEs/wImx246xhOU6WyrhBVMLZPp1MGCKKGexxOQKhHSbK6RzOguSYKT15nfO7JVDde3+nCGc6EPxAagaA==",
+      "dependencies": {
+        "@microsoft/1ds-core-js": "4.3.8",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.3.8.tgz",
+      "integrity": "sha512-uj60YhHTxcHLjLUHRPe2Y9VVdDOcam4/pdBBCbJ6/hkBWh6KZznnM3vb6JRbBVwD69Iq6tdGNWJRSCWNpZhLaA==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "3.3.8",
+        "@microsoft/applicationinsights-core-js": "3.3.8",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.8.tgz",
+      "integrity": "sha512-yfcU3g05Z36S3r4SDtV+LGkoubT3px6Yt4fwINIGDixbTJB6VZXQxLwkTAzWxKwxuvBX2L8PP9O1LY4D7gGrrA==",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.3.8",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.3.8.tgz",
+      "integrity": "sha512-k1uQCRSbV0aUF4DxgTFAbbk1IlsihLoldgQCMIVwHdnS3X80NjtSDWQPy0n+Hbw1XNlpky9p8jxNDJlZ9PoFDg==",
+      "dependencies": {
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-shims": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+      "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-web-basic": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.3.8.tgz",
+      "integrity": "sha512-etHqbg6zwDxObY7GUF1CZZtoNIzzfjzvJyOEvixwnio4ehHyxZLQXBTavoUL424/A2MgWTBQjj6AV2ezayoz4A==",
+      "dependencies": {
+        "@microsoft/applicationinsights-channel-js": "3.3.8",
+        "@microsoft/applicationinsights-common": "3.3.8",
+        "@microsoft/applicationinsights-core-js": "3.3.8",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/dynamicproto-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.3.tgz",
+      "integrity": "sha512-JTWTU80rMy3mdxOjjpaiDQsTLZ6YSGGqsjURsY6AUQtIj0udlF/jYmhdLZu8693ZIC0T1IwYnFa0+QeiMnziBA==",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.10.4 < 2.x"
+      }
+    },
+    "node_modules/@nevware21/ts-async": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.4.tgz",
+      "integrity": "sha512-IBTyj29GwGlxfzXw2NPnzty+w0Adx61Eze1/lknH/XIVdxtF9UnOpk76tnrHXWa6j84a1RR9hsOcHQPFv9qJjA==",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
+      }
+    },
+    "node_modules/@nevware21/ts-utils": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.12.5.tgz",
+      "integrity": "sha512-JPQZWPKQJjj7kAftdEZL0XDFfbMgXCGiUAZe0d7EhLC3QlXTlZdSckGqqRIQ2QNl0VTEZyZUvRBw6Ednw089Fw=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -871,6 +985,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vscode/extension-telemetry": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-1.0.0.tgz",
+      "integrity": "sha512-vaTZE65zigWwSWYB6yaZUAyVC/Ux+6U82hnzy/ejuS/KpFifO+0oORNd5yAoPeIRnYjvllM6ES3YlX4K5tUuww==",
+      "dependencies": {
+        "@microsoft/1ds-core-js": "^4.3.4",
+        "@microsoft/1ds-post-js": "^4.3.4",
+        "@microsoft/applicationinsights-web-basic": "^3.3.4"
+      },
+      "engines": {
+        "vscode": "^1.75.0"
       }
     },
     "node_modules/@vscode/test-cli": {
@@ -4775,6 +4902,12 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "peer": true
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4984,15 +5117,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/vscode-extension-telemetry": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.4.5.tgz",
-      "integrity": "sha512-YhPiPcelqM5xyYWmD46jIcsxLYWkPZhAxlBkzqmpa218fMtTT17ERdOZVCXcs1S5AjvDHlq43yCgi8TaVQjjEg==",
-      "deprecated": "This package has been renamed to @vscode/extension-telemetry, please update to the new name",
-      "engines": {
-        "vscode": "^1.60.0"
       }
     },
     "node_modules/vscode-json-languageservice": {

--- a/package.json
+++ b/package.json
@@ -741,7 +741,7 @@
     "bufferutil": "^4.0.9",
     "home-assistant-js-websocket": "^9.5.0",
     "utf-8-validate": "^6.0.5",
-    "vscode-extension-telemetry": "0.4.5",
+    "@vscode/extension-telemetry": "^1.0.0",
     "vscode-json-languageservice": "4.1.0",
     "vscode-languageclient": "^7.0.0",
     "vscode-languageserver": "^9.0.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+
 import * as path from "path";
 import * as vscode from "vscode";
 import { LanguageClientOptions } from "vscode-languageclient";
@@ -7,7 +7,7 @@ import {
   ServerOptions,
   TransportKind,
 } from "vscode-languageclient/node";
-import TelemetryReporter from "vscode-extension-telemetry";
+import { TelemetryReporter } from "@vscode/extension-telemetry";
 import { AuthManager } from "./auth/manager";
 import { AuthMiddleware } from "./auth/middleware";
 import { manageAuth, testConnection } from "./auth/commands";
@@ -15,11 +15,6 @@ import { debugAuthSettings } from "./auth/debug";
 import { repairAuthConfiguration } from "./auth/repair";
 import { HomeAssistantStatusBar } from "./status/statusBar";
 import { registerReloadCommands } from "./commands/reloadCommands";
-
-const extensionId = "vscode-home-assistant";
-const telemetryVersion = generateVersionString(
-  vscode.extensions.getExtension(`keesschollaart.${extensionId}`),
-);
 
 let reporter: TelemetryReporter;
 
@@ -53,11 +48,7 @@ export async function activate(
     console.error("Failed to migrate credentials:", error);
   }
 
-  reporter = new TelemetryReporter(
-    extensionId,
-    telemetryVersion,
-    "ff172110-5bb2-4041-9f31-e157f1efda56",
-  );
+  reporter = new TelemetryReporter("InstrumentationKey=ff172110-5bb2-4041-9f31-e157f1efda56");
 
   try {
     reporter.sendTelemetryEvent("extension.activate");
@@ -522,17 +513,6 @@ export async function deactivate(): Promise<void> {
   await reporter.dispose();
 }
 
-function generateVersionString(extension: vscode.Extension<any>): string {
-  // if the extensionPath is a Git repo, this is probably an extension developer
-  const isDevMode: boolean = extension
-    ? fs.existsSync(`${extension.extensionPath}/.git`)
-    : false;
-  const baseVersion: string = extension
-    ? extension.packageJSON.version
-    : "0.0.0";
-
-  return isDevMode ? `${baseVersion}-dev` : baseVersion;
-}
 
 export class CommandMappings {
   constructor(


### PR DESCRIPTION
Fixes:

```
npm warn deprecated [vscode-extension-telemetry@0.4.5](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html): This package has been renamed to @vscode/extension-telemetry, please update to the new name
```

