### PR TITLE
Only show config attribute description when hovering the YAML key

### DIFF
--- a/test-workspace/test-hover-behavior.yaml
+++ b/test-workspace/test-hover-behavior.yaml
@@ -1,0 +1,26 @@
+# Test file for hover behavior
+# Schema descriptions should only appear when hovering over keys, not values
+
+homeassistant:
+  name: "My Home Assistant"
+  time_zone: "America/New_York"
+  elevation: 123
+
+automation:
+  - alias: "Test Automation"
+    trigger:
+      platform: state
+      entity_id: sensor.temperature
+    action:
+      - service: light.turn_on
+        target:
+          entity_id: light.living_room
+        data:
+          brightness: 255
+
+sensor:
+  - platform: template
+    sensors:
+      test_sensor:
+        friendly_name: "Test Sensor"
+        value_template: "{{ states('sensor.original') }}"


### PR DESCRIPTION
This PR scopes the documentation for a YAML key/configuration attribute to the YAML key itself, and not the value set:

![CleanShot 2025-05-26 at 23 19 11](https://github.com/user-attachments/assets/1df2c220-6894-407a-8fdb-d90ca92ad5c3)
