### PR TITLE
Support action for auto completion in addition to service

### DIFF
--- a/src/language-service/src/completionHelpers/services.ts
+++ b/src/language-service/src/completionHelpers/services.ts
@@ -9,7 +9,7 @@ import { IHaConnection } from "../home-assistant/haConnection";
 import { HassService } from "home-assistant-js-websocket";
 
 export class ServicesCompletionContribution implements JSONWorkerContribution {
-  public static propertyMatches: string[] = ["service"];
+  public static propertyMatches: string[] = ["service", "action"];
 
   constructor(private haConnection: IHaConnection) {}
 


### PR DESCRIPTION
Home Assistant now uses the `action` key for calling service actions (instead of the `service` key). This pull request ensures auto-complete functions for `action` as well.

![CleanShot 2025-05-27 at 08 21 08](https://github.com/user-attachments/assets/e7e7212c-3863-4f4c-a70f-53c2f17508e6)
