### PR TITLE
Add error handling and display render issue when rendering template

### DIFF
--- a/src/language-service/src/home-assistant/haConnection.ts
+++ b/src/language-service/src/home-assistant/haConnection.ts
@@ -1102,7 +1102,6 @@ export class HaConnection implements IHaConnection {
   public callApi = async (
     method: Method,
     api: string,
-
     requestBody?: any,
   ): Promise<any> => {
     try {
@@ -1117,7 +1116,33 @@ export class HaConnection implements IHaConnection {
 
       return resp.data;
     } catch (error) {
-      console.error(error);
+      console.error(`Error calling API ${api}:`, error);
+      
+      // Extract error information for better error messages
+      if (error.response) {
+        // The request was made and the server responded with a status code outside of 2xx range
+        console.error(`Response status: ${error.response.status}`);
+        console.error(`Response data:`, error.response.data);
+        
+        // Return the error data to allow the caller to handle it
+        return error.response.data;
+      } else if (error.request) {
+        // The request was made but no response was received
+        return { error: "No response received from Home Assistant" };
+      } else {
+        // Something happened in setting up the request
+        if (typeof error === "object" && error !== null) {
+          if (error.message) {
+            return { error: error.message };
+          }
+          try {
+            return { error: JSON.stringify(error) };
+          } catch {
+            return { error: "Unknown error occurred" };
+          }
+        }
+        return { error: String(error) };
+      }
     }
     return Promise.resolve("");
   };


### PR DESCRIPTION
closes #2207

If template rendering fails, it will show the output.

![image](https://github.com/user-attachments/assets/7dc577e8-3653-4292-91ec-63db4af1a860)
