### PR TITLE
Fix YAML parse and schema

### DIFF
--- a/src/language-service/src/haConfig/haYamlFile.ts
+++ b/src/language-service/src/haConfig/haYamlFile.ts
@@ -208,7 +208,7 @@ export class HomeAssistantYamlFile {
       return;
     }
 
-    value = x.value.toString().slice(7, -1).replace(/\\/g, "/"); // \ to / on windows
+    value = x.value.toString().replace(/\\/g, "/"); // \ to / on windows
 
     let files: string[] = [];
 


### PR DESCRIPTION
Closes #3610

Fixing the YAML file parse, which was slicing the node value, but since the YAML parser was updated, this slice isn't necessary anymore, which was breaking the folder resolution, generating an error, and preventing the YAML language server from being configured.