### PR TITLE
migrating to new eslint extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"ms-vscode.vscode-typescript-tslint-plugin"
+		"dbaeumer.vscode-eslint"
 	]
 }


### PR DESCRIPTION
As per https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin, TSLint is deprecated in favor of ESLint and its tooling.