### PR TITLE
Schema support for time trigger with offset

### DIFF
--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -15,6 +15,7 @@ import {
   PersonEntities,
   ZoneEntities,
   SensorEntities,
+  SensorEntityOffsetOrList,
   NumberEntity,
   SensorEntity,
   CalendarEntity,
@@ -784,12 +785,12 @@ interface TimeTrigger {
 
   /**
    * Time of day to trigger on, in HH:MM:SS, 24 hours clock format. For example: "13:30:00"
-   * Also accepts input_datetime entities (e.g., input_datetime.start_of_day)
+   * Also accepts input_datetime entities (e.g., input_datetime.start_of_day), or sensor entities (e.g., sensor.sunrise) with an optional time offset.
    *
    * @TJS-pattern ^((input_datetime|sensor)\.(?!_)[\da-z_]+(?<!_)\s?(?:,\s?(input_datetime|sensor)\.(?!_)[\da-z_]+(?<!_))*|(?:[01]\d|2[0123]):(?:[012345]\d)(:(?:[012345]\d))?)$
    * @items.pattern ^((input_datetime|sensor)\.(?!_)[\da-z_]+(?<!_)|(?:[01]\d|2[0123]):(?:[012345]\d)(:(?:[012345]\d))?)$
    */
-  at: Times | InputDatetimeEntities | SensorEntities;
+  at: Times | InputDatetimeEntities | SensorEntities | SensorEntityOffsetOrList;
 
   /**
    * An personal identifier for this trigger, that is passed into the trigger

--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -393,6 +393,22 @@ export type SensorEntity = `sensor.${EntitySuffix}`;
  */
 export type SensorEntities = SensorEntity | SensorEntity[];
 
+interface SensorEntityOffset {
+  /**
+   * The sensor entity ID to monitor for.
+   * https://www.home-assistant.io/docs/automation/trigger/#sensors-of-datetime-device-class-with-offsets
+   */
+  entity_id: SensorEntity;
+
+  /**
+   * Optional offset that adjusts the trigger relative to the sensor’s time.
+   * https://www.home-assistant.io/docs/automation/trigger/#sensors-of-datetime-device-class-with-offsets
+   */
+  offset?: TimePeriod;
+}
+
+export type SensorEntityOffsetOrList = SensorEntityOffset | SensorEntityOffset[];
+
 /**
  * @TJS-pattern ^weather\.(?!_)[\da-z_]+(?<!_)$
  */


### PR DESCRIPTION
Schema support for automation's `time` trigger with a sensor entity and an offset - see also [this documentation](https://www.home-assistant.io/docs/automation/trigger/#sensors-of-datetime-device-class-with-offsets). 

For example:

```
automation:
  - triggers:
      - trigger: time
        at:
          entity_id: sensor.phone_next_alarm
          offset: -00:05:00
```