### PR TITLE
Rename 'trigger' to 'triggers' in template schema

### DIFF
--- a/src/language-service/src/schemas/integrations/core/template.ts
+++ b/src/language-service/src/schemas/integrations/core/template.ts
@@ -89,7 +89,7 @@ export interface Item {
    * Define an automation trigger to update the entities. Optional. If omitted will update based on referenced entities. See trigger documentation.
    * https://www.home-assistant.io/integrations/template#trigger
    */
-  trigger?: Trigger | Trigger[] | IncludeList;
+  triggers?: Trigger | Trigger[] | IncludeList;
 
   /**
    * The unique ID for this config block. This will be prefixed to all unique IDs of all entities in this block.


### PR DESCRIPTION
template triggers is not recognized

```yaml
template:
  - triggers:
    - trigger: time_pattern
      minutes: "/5"
    - trigger: state
      entity_id:
```

<img width="1714" height="274" alt="image" src="https://github.com/user-attachments/assets/d47bbbe2-eb4f-4a1e-b424-497533634d08" />

docs
https://www.home-assistant.io/integrations/template#trigger-based-template-entities

It seems to be typo because there is no `trigger` sub-element in the `template` only `triggers`

not tested, don't know how to build it locally, it would be nice if CI could build these artifacts for me