### PR TITLE
Fix automation schema mapping

### DIFF
--- a/src/language-service/src/schemas/integrations/core/automation.ts
+++ b/src/language-service/src/schemas/integrations/core/automation.ts
@@ -16,6 +16,7 @@ import { Trigger } from "../triggers";
 export type Domain = "automation";
 export type Schema = Item[] | IncludeList;
 export type File = Item | Item[];
+export type AutomationFile = Item | Item[];
 
 export type Mode = "single" | "parallel" | "queued" | "restart";
 type Item = AutomationItem | BlueprintItem;

--- a/src/language-service/src/schemas/mappings.json
+++ b/src/language-service/src/schemas/mappings.json
@@ -116,7 +116,7 @@
     "path": "configuration.yaml/automation",
     "file": "integration-automation.json",
     "tsFile": "integrations/core/automation.ts",
-    "fromType": "File"
+    "fromType": "AutomationFile"
   },
   {
     "key": "integration-binary_sensor",


### PR DESCRIPTION
Fixes an issue causing automations to break, introduced in #3740.

<img width="1976" height="804" alt="CleanShot 2025-11-16 at 10 45 50@2x" src="https://github.com/user-attachments/assets/cd659be0-2933-46e6-a186-82a8042ae6cd" />

This was caused by a circular dependency in typescript-json-schema to pick up the wrong File type.

This PR address that issue.

../Frenck  

<p>
  <a href="https://www.linkedin.com/in/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/linkedin.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://youtube.com/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/youtube.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://bsky.app/profile/frenck.social"><img src="https://github.com/frenck/frenck/raw/main/images/bluesky.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://fosstodon.org/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/mastodon.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.instagram.com/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/instagram.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.threads.net/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/threads.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.facebook.com/frenck.dev/"><img src="https://github.com/frenck/frenck/raw/main/images/facebook.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://x.com/frenck"><img src="https://github.com/frenck/frenck/raw/main/images/x.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.tiktok.com/@frenck.nl"><img src="https://github.com/frenck/frenck/raw/main/images/tiktok.svg" width="18" height="18"></a>
</p>

Blogging my personal ramblings at <a href="https://frenck.dev">frenck.dev</a>