### PR TITLE
Fix WebSocket connection issue with trailing slashes

### DIFF
--- a/src/auth/debug.ts
+++ b/src/auth/debug.ts
@@ -121,9 +121,11 @@ export async function debugAuthSettings(context: vscode.ExtensionContext): Promi
     }
     
     try {
-      const parsedUrl = new URL(`${activeUrl}/api/`);
+      // Remove trailing slashes to prevent double slashes in the path
+      const normalizedUrl = activeUrl.replace(/\/+$/, "");
+      const parsedUrl = new URL(`${normalizedUrl}/api/`);
       const agent = parsedUrl.protocol === "https:" ? new https.Agent({ rejectUnauthorized: !ignoreCertificates }) : undefined;
-      
+
       const request = (parsedUrl.protocol === "https:" ? https : http).request(
         {
           hostname: parsedUrl.hostname,
@@ -204,7 +206,9 @@ export async function testHomeAssistantConnection(
 ): Promise<{ success: boolean; message: string; data?: any }> {
   return new Promise((resolve, reject) => {
     try {
-      const apiUrl = new URL(`${url}/api/`);
+      // Remove trailing slashes to prevent double slashes in the path
+      const normalizedUrl = url.replace(/\/+$/, "");
+      const apiUrl = new URL(`${normalizedUrl}/api/`);
       const options = {
         method: "GET",
         headers: {
@@ -249,7 +253,7 @@ export async function testHomeAssistantConnection(
               
               // If we still don't have the version, try a second call to /api/config
               if (version === "unknown") {
-                const configUrl = new URL(`${url}/api/config`);
+                const configUrl = new URL(`${normalizedUrl}/api/config`);
                 const configReq = requestLib.request(configUrl, options, (configRes) => {
                   let configData = "";
                   configRes.on("data", (chunk) => {

--- a/src/language-service/src/home-assistant/haConnection.ts
+++ b/src/language-service/src/home-assistant/haConnection.ts
@@ -207,7 +207,9 @@ export class HaConnection implements IHaConnection {
     
     if (hassUrl) {
       try {
-        const url = new URL(`${hassUrl}/api/websocket`);
+        // Remove trailing slashes to prevent double slashes in the path
+        const normalizedUrl = hassUrl.replace(/\/+$/, "");
+        const url = new URL(`${normalizedUrl}/api/websocket`);
         const wsProtocol = url.protocol === "https:" ? "wss:" : "ws:";
         wsUrl = `${wsProtocol}//${url.host}${url.pathname}`;
         console.log(`Generated WebSocket URL: ${wsUrl}`);


### PR DESCRIPTION
 Fixes a regression introduced in #3707 where URLs with trailing slashes caused authentication failures.

PR #3707 changed the WebSocket URL construction to support subpaths, but when the Home Assistant URL has a trailing slash (e.g., `http://10.10.10.100:8123/`), it creates a double slash in the
 path (`//api/websocket`), which Home Assistant doesn't recognize, causing `auth_invalid` errors.

Normalize URLs by removing trailing slashes before concatenating `/api/websocket`. This:
- Fixes the double slash issue
- Preserves subpath support from #3707
- Works with URLs with or without trailing slashes

Verified the fix handles all cases correctly:
- `http://10.10.10.100:8123` → `ws://10.10.10.100:8123/api/websocket` ✅
- `http://10.10.10.100:8123/` → `ws://10.10.10.100:8123/api/websocket` ✅
- `http://10.10.10.100:8123/homeassistant` → `ws://10.10.10.100:8123/homeassistant/api/websocket` ✅
- `http://10.10.10.100:8123/homeassistant/` → `ws://10.10.10.100:8123/homeassistant/api/websocket` ✅