### PR TITLE
Add support for the reorder property in entity selector configurations

### DIFF
--- a/src/language-service/src/schemas/integrations/selectors.ts
+++ b/src/language-service/src/schemas/integrations/selectors.ts
@@ -439,6 +439,12 @@ export interface EntitySelector {
      * https://www.home-assistant.io/docs/blueprint/selectors/#entity-selector
      */
     multiple?: boolean;
+
+    /**
+     * Allows reordering of entities (only applies if `multiple` is set to `true`).
+     * https://www.home-assistant.io/docs/blueprint/selectors/#entity-selector
+     */
+    reorder?: boolean;
   } | null;
 }
 


### PR DESCRIPTION
The extension's schema was missing the `reorder` property for entity selectors, causing validation errors when users imported blueprints that included this property. This property is automatically added by Home Assistant when blueprints are imported with entity selectors that have `multiple: true`.

fixes #3816

The following YAML will no longer show a validation error:

```yaml
selector:
  entity:
    multiple: true
    filter:
      - domain:
          - binary_sensor
    reorder: false
```
