### PR TITLE
Only show action buttons in the tab bar when an HA-related file is open

### DIFF
--- a/package.json
+++ b/package.json
@@ -566,17 +566,20 @@
         {
           "command": "vscode-home-assistant.reloadAll",
           "title": "Home Assistant: Quick reload all",
-          "group": "navigation@1"
+          "group": "navigation@1",
+          "when": "editorLangId == home-assistant"
         },
         {
           "command": "vscode-home-assistant.showReloadIntegrations",
           "title": "Home Assistant: Reload specific integration",
-          "group": "navigation@2"
+          "group": "navigation@2",
+          "when": "editorLangId == home-assistant"
         },
         {
           "command": "vscode-home-assistant.homeassistantRestart",
           "title": "Home Assistant: Restart Home Assistant",
-          "group": "navigation@3"
+          "group": "navigation@3",
+          "when": "editorLangId == home-assistant"
         }
       ],
       "home-assistant.reload": [


### PR DESCRIPTION
Fix editor title bar action buttons to only appear when Home Assistant files are open by adding `when` clauses to the three commands that were always visible.

Added `when: "editorLangId == home-assistant"` condition to three editor title bar commands:
- Quick reload all
- Reload specific integration
- Restart Home Assistant

Previously, these three action buttons appeared in the editor title bar at all times, regardless of which file was open. This cluttered the UI when working on non-Home Assistant files in the
same workspace.

With this change, the buttons only appear when a file with the `home-assistant` language ID is active (typically `.yaml`/`.yml` files in a Home Assistant workspace).

Closes #3765