### PR TITLE
Fix packages to not be root level

### DIFF
--- a/src/language-service/src/schemas/integrations/core/homeassistant.ts
+++ b/src/language-service/src/schemas/integrations/core/homeassistant.ts
@@ -122,7 +122,7 @@ export interface Schema {
    * Packages in Home Assistant provide a way to bundle different component’s configuration together. It allows for "splitting" your configuration.
    * https://www.home-assistant.io/docs/configuration/packages/
    */
-  packages?: ConfigurationRoot | IncludeNamed;
+  packages?: IncludeNamed;
 
   /**
    * Pick your time zone from the column TZ of Wikipedia’s list of tz database time


### PR DESCRIPTION
Packages should be nested under homeassistant:
```yaml
homeassistant:
  packages: !include_dir_named integrations
```

Schema was expecting:
```yaml
homeassistant:
packages: !include_dir_named integrations
```
