### PR TITLE
add support for `weekday` in `automation.triggers`

### DIFF
--- a/src/language-service/src/schemas/integrations/triggers.ts
+++ b/src/language-service/src/schemas/integrations/triggers.ts
@@ -70,6 +70,7 @@ type EventType =
 
 type AllowedMethods = "POST" | "PUT" | "GET" | "HEAD";
 type PersistentNotificationUpdateType = "added" | "updated" | "removed";
+export type Weekday = "mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun";
 
 interface CalendarTrigger {
   /**
@@ -808,6 +809,12 @@ interface TimeTrigger {
    * https://www.home-assistant.io/docs/automation/trigger#trigger-variables
    */
   variables?: Data;
+
+  /**
+   * Optional weekday, accepts a single day or a list of days.
+   * https://www.home-assistant.io/docs/automation/trigger/#weekday-filtering
+   */
+  weekday?: Weekday | Weekday[];
 }
 
 interface TimePatternTrigger {


### PR DESCRIPTION
Solves:

<img width="424" height="223" alt="SCR-20251215-unxy" src="https://github.com/user-attachments/assets/d526a29c-e330-4105-8c66-92e886e50ce3" />

I've elected to duplicate `Weekday`s definition from `"./conditions"` because importing it from that module seems a bit dirty to me and I don't really know where is a more central place to put the common definition if we want to reuse. Happy to change that.