### PR TITLE
Add support for event group address wildcards

### DIFF
--- a/src/language-service/src/schemas/integrations/core/knx.ts
+++ b/src/language-service/src/schemas/integrations/core/knx.ts
@@ -21,6 +21,12 @@ import {
 type GroupAddress = string;
 
 /**
+ * @TJS-pattern ^(\d{1,2}\/\d{1,2}\/(\d{1,4}(-\d{1,4})?|\*)|\d{1,2}\/(\d{1,4}|\*)|\*|\d{1,5}|i-.+)$
+ * @items.pattern ^(\d{1,2}\/\d{1,2}\/(\d{1,4}(-\d{1,4})?|\*)|\d{1,2}\/(\d{1,4}|\*)|\*|\d{1,5}|i-.+)$
+ */
+type GroupAddressesEvent = string[] | string;
+
+/**
  * @TJS-pattern ^(\d{1,2}(\/\d{1,2})?\/\d{1,4}|\d{1,5}|i-.+)$
  * @items.pattern ^(\d{1,2}(\/\d{1,2})?\/\d{1,4}|\d{1,5}|i-.+)$
  */
@@ -795,10 +801,10 @@ interface Cover {
 
 interface Event {
   /**
-   * KNX group address to fire events.
-   * https://www.home-assistant.io/integrations/knx#state_address
+   * KNX group address to fire events. Patterns with wildcards (*) and ranges (2-4) are supported.
+   * https://www.home-assistant.io/integrations/knx#events
    */
-  address: GroupAddresses;
+  address: GroupAddressesEvent;
 
   /**
    * A type from the value types. The decoded value will be written to the event data `value` key.


### PR DESCRIPTION
Current schema does not support wildcards in KNX addresses.

These are supported by the KNX integration as per https://www.home-assistant.io/integrations/knx#events

This PR adds support for wildcards to the schema.