### PR TITLE
Add IncludeList to modbus entity properties

### DIFF
--- a/src/language-service/src/schemas/integrations/core/modbus.ts
+++ b/src/language-service/src/schemas/integrations/core/modbus.ts
@@ -7,6 +7,7 @@ import {
   DeviceClassesBinarySensor,
   DeviceClassesCover,
   DeviceClassesSensor,
+  IncludeList,
   Integer,
   StateClassesSensor,
 } from "../../types";
@@ -98,43 +99,43 @@ interface Item {
    * A list of all binary sensors configured for this connection.
    * https://www.home-assistant.io/integrations/modbus/#binary_sensors
    */
-  binary_sensors?: BinarySensorItem | BinarySensorItem[];
+  binary_sensors?: BinarySensorItem | BinarySensorItem[] | IncludeList;
 
   /**
    * A list of all climate entities in this modbus instance.
    * https://www.home-assistant.io/integrations/modbus/#climates
    */
-  climates?: ClimateItem | ClimateItem[];
+  climates?: ClimateItem | ClimateItem[] | IncludeList;
 
   /**
    * A list of all cover entities configured for this connection.
    * https://www.home-assistant.io/integrations/modbus/#covers
    */
-  covers?: CoverItem | CoverItem[];
+  covers?: CoverItem | CoverItem[] | IncludeList;
 
   /**
    * A list of all fan entities in this modbus instance.
    * https://www.home-assistant.io/integrations/modbus/#fans
    */
-  fans?: FanItem | FanItem[];
+  fans?: FanItem | FanItem[] | IncludeList;
 
   /**
    * A list of all light entities in this modbus instance.
    * https://www.home-assistant.io/integrations/modbus/#lights
    */
-  lights?: LightItem | LightItem[];
+  lights?: LightItem | LightItem[] | IncludeList;
 
   /**
    * A list of all sensors in this modbus instance.
    * https://www.home-assistant.io/integrations/modbus/#sensors
    */
-  sensors?: SensorItem | SensorItem[];
+  sensors?: SensorItem | SensorItem[] | IncludeList;
 
   /**
    * A list of all switches in this modbus instance.
    * https://www.home-assistant.io/integrations/modbus/#switches
    */
-  switches?: SwitchItem | SwitchItem[];
+  switches?: SwitchItem | SwitchItem[] | IncludeList;
 }
 
 interface BaseEntityItem {


### PR DESCRIPTION
To support include_dir_list and include_dir_merge_list in modbus configuration and avoid following error:

<img width="934" height="114" alt="image" src="https://github.com/user-attachments/assets/a8f40b02-53f2-4632-9a8b-a7c8e86ef2b0" />
