### PR TITLE
fix: add missing name and default_entity_id to Item interface, make SwitchItem extend BaseItem

### DIFF
--- a/src/language-service/src/schemas/integrations/core/template.ts
+++ b/src/language-service/src/schemas/integrations/core/template.ts
@@ -153,6 +153,17 @@ export interface Item {
   use_blueprint?: BlueprintUsage;
 
   /**
+   * Defines a template to get the name of the entity.
+   * https://www.home-assistant.io/integrations/template#name
+   */
+  name?: Template;
+
+  /**
+   * Use default_entity_id instead of name for automatic generation of the entity id. E.g. sensor.my_awesome_sensor. When used without a unique_id, the entity id will update during restart or reload if the entity id is available. If the entity id already exists, the entity id will be created with a number at the end. When used with a unique_id, the default_entity_id is only used when the entity is added for the first time. When set, this overrides a user-customized Entity ID in case the entity was deleted and added again.
+   * https://www.home-assistant.io/integrations/template#default_entity_id
+   */
+  default_entity_id?: string;
+  /**
    * The unique ID for this config block. This will be prefixed to all unique IDs of all entities in this block.
    * https://www.home-assistant.io/integrations/template#unique_id
    */
@@ -756,7 +767,7 @@ export interface SensorItem extends BaseItem {
   unit_of_measurement?: string;
 }
 
-interface SwitchItem {
+export interface SwitchItem extends BaseItem {
   /**
    * Defines a template to get the available state of the component. If the template returns true, the device is available.
    * https://www.home-assistant.io/integrations/switch.template#availability_template


### PR DESCRIPTION

Fixes #3973

I ran into this issue when my template switches were showing DisallowedExtraPropWarning for properties like `name` and `unique_id`. Looking for open issues, I found #3973 which described a similar problem with blueprint-based templates.

Turns out there were two related bugs.

1. **SwitchItem interface**: Wasn't extending BaseItem, so it was missing common properties.
2. **Item interface**: Was missing `name` and `default_entity_id` properties needed when using `use_blueprint`

This PR fixes both issues.

## Test Configuration

I tested with this configuration to verify both scenarios work correctly:

## Test Configuration
```yaml
# Blueprint with name and default_entity_id - now validates correctly
template:
  - use_blueprint:
      invalid_key: true  # Still shows error as expected
      path: blueprints/template/test_switch.yaml
      input:
        switch_name: "Living Room Light"
        entity_to_monitor: light.living_room
    name: "Blueprint Switch"
    unique_id: "blueprint_switch_001"
    default_entity_id: switch.living_room_light

# Switch using BaseItem properties
  - switch:
      - name: "Manual Switch"
        unique_id: "manual_switch_001"
        default_entity_id: switch.basement_heater
        turn_on:
          - action: light.turn_on
            target:
              entity_id: light.bedroom
        turn_off:
          - action: light.turn_off
            target:
              entity_id: light.bedroom
        state: "{{ is_state('light.bedroom', 'on') }}"
```
