### PR TITLE
Update device classes for sensors

### DIFF
--- a/src/language-service/src/schemas/types.ts
+++ b/src/language-service/src/schemas/types.ts
@@ -95,6 +95,7 @@ export type DeviceClassesMediaPlayer = "tv" | "speaker" | "receiver";
  * From: https://github.com/home-assistant/core/blob/dev/homeassistant/components/sensor/const.py
  */
 export type DeviceClassesSensor =
+  | "absolute_humidity"
   | "apparent_power"
   | "aqi"
   | "area"
@@ -129,17 +130,20 @@ export type DeviceClassesSensor =
   | "pm1"
   | "pm10"
   | "pm25"
+  | "pm4"
   | "power_factor"
   | "power"
   | "precipitation_intensity"
   | "precipitation"
   | "pressure"
+  | "reactive_energy"
   | "reactive_power"
   | "signal_strength"
   | "sound_pressure"
   | "speed"
   | "sulphur_dioxide"
   | "temperature"
+  | "temperature_delta"
   | "timestamp"
   | "volatile_organic_compounds"
   | "volatile_organic_compounds_parts"
@@ -149,6 +153,7 @@ export type DeviceClassesSensor =
   | "volume_storage"
   | "water"
   | "weight"
+  | "wind_direction"
   | "wind_speed";
 
 /**


### PR DESCRIPTION
I noticed that `temperature_delta` isn't supported as a a `device_class` for sensors despite it being available from the HA frontend. I realised this is due to the schema in this repo being outdated.

As per the sole commit:

> In order to keep up-to-date with the latest version of Home Assistant. This commit updates the device classes for sensors based on those defined in [home-assistant/core@2026.3.3][1].
>
> [1]: https://github.com/home-assistant/core/blob/c1bd83c9c05aea1d78754098a9c333625e93857f/homeassistant/components/sensor/const.py#L91
