### PR TITLE
Fix multiline ID validation scope

### DIFF
--- a/src/language-service/src/haLanguageService.ts
+++ b/src/language-service/src/haLanguageService.ts
@@ -311,6 +311,47 @@ export class HomeAssistantLanguageService {
     return diagnostics;
   };
 
+  /**
+   * Returns whether a sequence item belongs to a block-style property list.
+   *
+   * A blank line is not a YAML scope boundary. Walk backwards only until the
+   * current item's parent or sibling indentation is reached, so a list under
+   * an earlier property cannot capture unrelated list entries later in the
+   * document.
+   */
+  private isInMultiLinePropertyList(
+    lines: string[],
+    lineIndex: number,
+    propertyNames: string[],
+  ): boolean {
+    const itemIndent = lines[lineIndex].match(/^(\s*)/)?.[1].length ?? 0;
+
+    for (let index = lineIndex - 1; index >= 0; index--) {
+      const line = lines[index];
+      const trimmedLine = line.trim();
+
+      if (trimmedLine === "" || trimmedLine.startsWith("#")) {
+        continue;
+      }
+
+      const indent = line.match(/^(\s*)/)?.[1].length ?? 0;
+      const isProperty = propertyNames.some((propertyName) =>
+        new RegExp(`^\\s*${propertyName}\\s*:\\s*$`).test(line),
+      );
+
+      if (isProperty && indent <= itemIndent) {
+        return true;
+      }
+
+      // A sibling or parent mapping/list item ends the property list.
+      if (indent <= itemIndent) {
+        return false;
+      }
+    }
+
+    return false;
+  }
+
   private validateEntityIds = async (
     document: TextDocument,
   ): Promise<Diagnostic[]> => {
@@ -437,27 +478,11 @@ export class HomeAssistantLanguageService {
         
         // Handle multi-line entity arrays
         if (line.trim().startsWith("- ")) {
-          // Check if we're in an entity list context by looking at previous lines
-          let currentLineIndex = lineIndex - 1;
-          let foundEntityProperty = false;
-          
-          while (currentLineIndex >= 0 && lines[currentLineIndex].trim() !== "") {
-            const prevLine = lines[currentLineIndex];
-            
-            for (const propertyName of EntityIdCompletionContribution.propertyMatches) {
-              if (new RegExp(`\\s*${propertyName}\\s*:\\s*$`).test(prevLine)) {
-                foundEntityProperty = true;
-                break;
-              }
-            }
-            
-            if (foundEntityProperty) {
-              break;
-            }
-            currentLineIndex--;
-          }
-          
-          if (foundEntityProperty) {
+          if (this.isInMultiLinePropertyList(
+            lines,
+            lineIndex,
+            EntityIdCompletionContribution.propertyMatches,
+          )) {
             const entityMatch = line.match(/^\s*-\s*([^#\n]+)/);
             if (entityMatch) {
               const entityValue = entityMatch[1].trim().replace(/^["']|["']$/g, "");
@@ -655,27 +680,11 @@ export class HomeAssistantLanguageService {
         
         // Handle multi-line area arrays
         if (line.trim().startsWith("- ")) {
-          // Check if we're in an area list context by looking at previous lines
-          let currentLineIndex = lineIndex - 1;
-          let foundAreaProperty = false;
-          
-          while (currentLineIndex >= 0 && lines[currentLineIndex].trim() !== "") {
-            const prevLine = lines[currentLineIndex];
-            
-            for (const propertyName of AreaCompletionContribution.propertyMatches) {
-              if (new RegExp(`\\s*${propertyName}\\s*:\\s*$`).test(prevLine)) {
-                foundAreaProperty = true;
-                break;
-              }
-            }
-            
-            if (foundAreaProperty) {
-              break;
-            }
-            currentLineIndex--;
-          }
-          
-          if (foundAreaProperty) {
+          if (this.isInMultiLinePropertyList(
+            lines,
+            lineIndex,
+            AreaCompletionContribution.propertyMatches,
+          )) {
             const areaMatch = line.match(/^\s*-\s*([^#\n]+)/);
             if (areaMatch) {
               const areaValue = areaMatch[1].trim().replace(/^["']|["']$/g, "");
@@ -883,27 +892,11 @@ export class HomeAssistantLanguageService {
         
         // Handle multi-line device arrays
         if (line.trim().startsWith("- ")) {
-          // Check if we're in a device list context by looking at previous lines
-          let currentLineIndex = lineIndex - 1;
-          let foundDeviceProperty = false;
-          
-          while (currentLineIndex >= 0 && lines[currentLineIndex].trim() !== "") {
-            const prevLine = lines[currentLineIndex];
-            
-            for (const propertyName of DeviceCompletionContribution.propertyMatches) {
-              if (new RegExp(`\\s*${propertyName}\\s*:\\s*$`).test(prevLine)) {
-                foundDeviceProperty = true;
-                break;
-              }
-            }
-            
-            if (foundDeviceProperty) {
-              break;
-            }
-            currentLineIndex--;
-          }
-          
-          if (foundDeviceProperty) {
+          if (this.isInMultiLinePropertyList(
+            lines,
+            lineIndex,
+            DeviceCompletionContribution.propertyMatches,
+          )) {
             const deviceMatch = line.match(/^\s*-\s*([^#\n]+)/);
             if (deviceMatch) {
               const deviceValue = deviceMatch[1].trim().replace(/^["']|["']$/g, "");
@@ -1111,27 +1104,11 @@ export class HomeAssistantLanguageService {
         
         // Handle multi-line floor arrays
         if (line.trim().startsWith("- ")) {
-          // Check if we're in a floor list context by looking at previous lines
-          let currentLineIndex = lineIndex - 1;
-          let foundFloorProperty = false;
-          
-          while (currentLineIndex >= 0 && lines[currentLineIndex].trim() !== "") {
-            const prevLine = lines[currentLineIndex];
-            
-            for (const propertyName of FloorCompletionContribution.propertyMatches) {
-              if (new RegExp(`\\s*${propertyName}\\s*:\\s*$`).test(prevLine)) {
-                foundFloorProperty = true;
-                break;
-              }
-            }
-            
-            if (foundFloorProperty) {
-              break;
-            }
-            currentLineIndex--;
-          }
-          
-          if (foundFloorProperty) {
+          if (this.isInMultiLinePropertyList(
+            lines,
+            lineIndex,
+            FloorCompletionContribution.propertyMatches,
+          )) {
             const floorMatch = line.match(/^\s*-\s*([^#\n]+)/);
             if (floorMatch) {
               const floorValue = floorMatch[1].trim().replace(/^["']|["']$/g, "");
@@ -1472,27 +1449,11 @@ export class HomeAssistantLanguageService {
         
         // Handle multi-line label arrays
         if (line.trim().startsWith("- ")) {
-          // Check if we're in a label list context by looking at previous lines
-          let currentLineIndex = lineIndex - 1;
-          let foundLabelProperty = false;
-          
-          while (currentLineIndex >= 0 && lines[currentLineIndex].trim() !== "") {
-            const prevLine = lines[currentLineIndex];
-            
-            for (const propertyName of LabelCompletionContribution.propertyMatches) {
-              if (new RegExp(`\\s*${propertyName}\\s*:\\s*$`).test(prevLine)) {
-                foundLabelProperty = true;
-                break;
-              }
-            }
-            
-            if (foundLabelProperty) {
-              break;
-            }
-            currentLineIndex--;
-          }
-          
-          if (foundLabelProperty) {
+          if (this.isInMultiLinePropertyList(
+            lines,
+            lineIndex,
+            LabelCompletionContribution.propertyMatches,
+          )) {
             const labelMatch = line.match(/^\s*-\s*([^#\n]+)/);
             if (labelMatch) {
               const labelValue = labelMatch[1].trim().replace(/^["']|["']$/g, "");
@@ -1725,27 +1686,11 @@ export class HomeAssistantLanguageService {
             continue;
           }
           
-          // Check if we're in an action list context by looking at previous lines
-          let currentLineIndex = lineIndex - 1;
-          let foundActionProperty = false;
-          
-          while (currentLineIndex >= 0 && lines[currentLineIndex].trim() !== "") {
-            const prevLine = lines[currentLineIndex];
-            
-            for (const propertyName of ServicesCompletionContribution.propertyMatches) {
-              if (new RegExp(`\\s*${propertyName}\\s*:\\s*$`).test(prevLine)) {
-                foundActionProperty = true;
-                break;
-              }
-            }
-            
-            if (foundActionProperty) {
-              break;
-            }
-            currentLineIndex--;
-          }
-          
-          if (foundActionProperty) {
+          if (this.isInMultiLinePropertyList(
+            lines,
+            lineIndex,
+            ServicesCompletionContribution.propertyMatches,
+          )) {
             const actionMatch = line.match(/^\s*-\s*([^#\n]+)/);
             if (actionMatch) {
               const actionValue = actionMatch[1].trim().replace(/^["']|["']$/g, "");

--- a/src/test/suite/device-validation-mock.test.ts
+++ b/src/test/suite/device-validation-mock.test.ts
@@ -224,6 +224,25 @@ automation:
     assert.strictEqual(deviceDiagnostics[0].message, "Device 'unknown_device' does not exist in your Home Assistant instance");
   });
 
+  test("Does not treat later list items as device IDs", async () => {
+    const content = `automation:
+  - alias: "Test Automation"
+    trigger:
+      device_id:
+        - device_1234
+    action:
+      - action: light.toggle
+        target:
+          entity_id: light.kitchen
+`;
+
+    const document = TextDocument.create("file://test.yaml", "yaml", 1, content);
+    const diagnostics = await languageService.getDiagnostics(document);
+    const deviceDiagnostics = diagnostics.filter(d => d.code === "unknown-device");
+
+    assert.strictEqual(deviceDiagnostics.length, 0);
+  });
+
   test("Should skip template devices", async () => {
     const content = `
 automation:


### PR DESCRIPTION
## Summary

- Bound multiline registry-ID validation to the current YAML block.
- Add a regression test covering a later action list after a block-style `device_id:` list.

## Root cause

The multiline validators scanned backward until a blank line, allowing an earlier `*_id:` list to validate unrelated later list entries. This follows the indentation-boundary diagnosis in [keesschollaart81/vscode-home-assistant#3938](https://github.com/keesschollaart81/vscode-home-assistant/issues/3938#issuecomment-4854744058).

The same repeated scan affected entity, area, device, floor, label, and action validation.

## Related issues

- Closes #3938.
- Also addresses the corresponding Studio Code Server report: [hassio-addons/addon-vscode#1056](https://github.com/hassio-addons/addon-vscode/issues/1056).

## Validation

- `npm run lint:types`
- `npm run lint:eslint` (existing warnings only)
- Focused regression reproduction

## Screenshots

Before (left) / after (right):
<img width="1918" height="765" alt="image" src="https://github.com/user-attachments/assets/cc3d1ebf-aa37-4a18-9d2a-efdd9d4e309f" />
<img width="1966" height="571" alt="image" src="https://github.com/user-attachments/assets/68d0cbbf-946d-43d4-ada5-7a16e285e190" />

See how the false-positive errors, both "Area ... does not exist" and "Entity ... does not exist" are gone now 👌
