### PR TITLE
Distinguish disabled entities from truly not existing ones, in validation

### DIFF
--- a/src/language-service/src/haLanguageService.ts
+++ b/src/language-service/src/haLanguageService.ts
@@ -24,7 +24,10 @@ import { DeviceCompletionContribution } from "./completionHelpers/deviceIds";
 import { EntityIdCompletionContribution } from "./completionHelpers/entityIds";
 import { FloorCompletionContribution } from "./completionHelpers/floors";
 import { LabelCompletionContribution } from "./completionHelpers/labels";
-import { HaConnection } from "./home-assistant/haConnection";
+import {
+  HaConnection,
+  HassEntityRegistry,
+} from "./home-assistant/haConnection";
 import { ServicesCompletionContribution } from "./completionHelpers/services";
 import { DomainCompletionContribution } from "./completionHelpers/domains";
 import { UuidCompletionContribution } from "./completionHelpers/uuids";
@@ -317,8 +320,16 @@ export class HomeAssistantLanguageService {
     const diagnostics: Diagnostic[] = [];
     
     try {
-      // Get all entities from Home Assistant
-      const entities = await this.haConnection.getHassEntities();
+      // Fetch the live state and entity registry caches concurrently.
+      const [entities, entityRegistry] = await Promise.all([
+        this.haConnection.getHassEntities(),
+        this.haConnection.getHassEntityRegistry().catch((error): HassEntityRegistry => {
+          // A registry lookup improves the diagnostic but must not prevent
+          // unknown-entity validation when the registry is unavailable.
+          console.log("Could not fetch the Home Assistant entity registry:", error);
+          return {};
+        }),
+      ]);
       if (!entities) {
         // If we can't get entities (e.g., not connected), don't validate
         console.log("Entity validation skipped: No entities available from Home Assistant");
@@ -327,6 +338,20 @@ export class HomeAssistantLanguageService {
 
       const entityIds = Object.keys(entities);
       console.log(`Entity validation: Found ${entityIds.length} entities from Home Assistant`);
+      const getEntityDiagnosticDetails = (entityId: string) => {
+        const entityRegistryEntry = entityRegistry[entityId];
+        if (entityRegistryEntry && entityRegistryEntry.disabled_by !== null) {
+          return {
+            code: "disabled-entity",
+            message: `Entity '${entityId}' is disabled in your Home Assistant instance`,
+          };
+        }
+
+        return {
+          code: "unknown-entity",
+          message: `Entity '${entityId}' does not exist in your Home Assistant instance`,
+        };
+      };
       
       const text = document.getText();
       const lines = text.split("\n");
@@ -371,6 +396,7 @@ export class HomeAssistantLanguageService {
               console.log(`Entity validation: Found unknown entity '${cleanEntityValue}' at line ${lineIndex + 1}`);
               const startColumn = match.index! + match[0].indexOf(entityValue);
               const endColumn = startColumn + entityValue.length;
+              const diagnosticDetails = getEntityDiagnosticDetails(cleanEntityValue);
               
               const diagnostic: Diagnostic = {
                 severity: 2, // Warning
@@ -380,9 +406,9 @@ export class HomeAssistantLanguageService {
                   lineIndex,
                   endColumn,
                 ),
-                message: `Entity '${cleanEntityValue}' does not exist in your Home Assistant instance`,
+                message: diagnosticDetails.message,
                 source: "home-assistant",
-                code: "unknown-entity",
+                code: diagnosticDetails.code,
               };
               
               diagnostics.push(diagnostic);
@@ -415,6 +441,7 @@ export class HomeAssistantLanguageService {
                 const entityStartInArray = entitiesInArray.indexOf(entityInArray);
                 const startColumn = arrayMatch.index! + arrayMatch[0].indexOf("[") + 1 + entityStartInArray;
                 const endColumn = startColumn + entityInArray.length;
+                const diagnosticDetails = getEntityDiagnosticDetails(cleanEntityValue);
                 
                 const diagnostic: Diagnostic = {
                   severity: 2, // Warning
@@ -424,9 +451,9 @@ export class HomeAssistantLanguageService {
                     lineIndex,
                     endColumn,
                   ),
-                  message: `Entity '${cleanEntityValue}' does not exist in your Home Assistant instance`,
+                  message: diagnosticDetails.message,
                   source: "home-assistant",
-                  code: "unknown-entity",
+                  code: diagnosticDetails.code,
                 };
                 
                 diagnostics.push(diagnostic);
@@ -476,6 +503,7 @@ export class HomeAssistantLanguageService {
               if (!entityIds.includes(entityValue)) {
                 const startColumn = entityMatch.index! + entityMatch[0].indexOf(entityValue);
                 const endColumn = startColumn + entityValue.length;
+                const diagnosticDetails = getEntityDiagnosticDetails(entityValue);
                 
                 const diagnostic: Diagnostic = {
                   severity: 2, // Warning
@@ -485,9 +513,9 @@ export class HomeAssistantLanguageService {
                     lineIndex,
                     endColumn,
                   ),
-                  message: `Entity '${entityValue}' does not exist in your Home Assistant instance`,
+                  message: diagnosticDetails.message,
                   source: "home-assistant",
-                  code: "unknown-entity",
+                  code: diagnosticDetails.code,
                 };
                 
                 diagnostics.push(diagnostic);

--- a/src/test/suite/entity-validation-mock.test.ts
+++ b/src/test/suite/entity-validation-mock.test.ts
@@ -61,6 +61,12 @@ class MockHaConnection implements IHaConnection {
     }
   };
 
+  private mockEntityRegistry: any = {};
+
+  setEntityRegistry(entityRegistry: any): void {
+    this.mockEntityRegistry = entityRegistry;
+  }
+
   async tryConnect(): Promise<void> {
     // Mock implementation
   }
@@ -106,7 +112,7 @@ class MockHaConnection implements IHaConnection {
   }
 
   async getHassEntityRegistry(): Promise<any> {
-    return {};
+    return this.mockEntityRegistry;
   }
 
   async getHassServices(): Promise<any> {
@@ -230,6 +236,36 @@ group:
         `Known entity '${knownEntity}' should not generate a diagnostic`
       );
     }
+  });
+
+  test("Entity validation identifies disabled entities", async () => {
+    mockConnection.setEntityRegistry({
+      "cover.disabled_cover": {
+        entity_id: "cover.disabled_cover",
+        disabled_by: "user",
+      },
+    });
+
+    const document = TextDocument.create(
+      "file:///test-disabled-entity.yaml",
+      "yaml",
+      1,
+      "entity_id: cover.disabled_cover\n",
+    );
+
+    const diagnostics = await languageService.getDiagnostics(document);
+    const entityDiagnostics = diagnostics.filter(
+      (diagnostic) => diagnostic.source === "home-assistant",
+    );
+
+    assert.strictEqual(entityDiagnostics.length, 1);
+    assert.strictEqual(entityDiagnostics[0].code, "disabled-entity");
+    assert.strictEqual(
+      entityDiagnostics[0].message,
+      "Entity 'cover.disabled_cover' is disabled in your Home Assistant instance",
+    );
+
+    mockConnection.setEntityRegistry({});
   });
 
   test("Entity validation skips templates and secrets", async () => {


### PR DESCRIPTION
## Summary

- Fetch live entity states and the existing entity-registry cache concurrently when validation begins.
- Report registry entries with `disabled_by` as disabled instead of missing.
- Preserve the existing missing-entity warning for IDs absent from the registry.

## Root cause

Disabled entities are absent from Home Assistant's live entity-state cache. The language server previously consulted only that cache, which made a disabled entity indistinguishable from an entity that does not exist.

## Validation

- `npx tsc -p src/language-service/tsconfig.json` passed.
- Added a focused mocked test for a generic disabled cover entity. The VS Code test harness could not reach the test because this checkout's schema-generation step exceeded 120 seconds before initialization; this draft needs that test run in CI or a fully generated local schema tree.

Tested on my HA instance: it correctly distinguishes between both issues. The first entity was reported as "missing" with the previous code, whereas it was indeed just disabled, whereas the second is obviously truly missing:
<img width="904" height="83" alt="image" src="https://github.com/user-attachments/assets/ae2f280f-3dd4-4a72-85e1-ae937c0f6456" />
