### PR TITLE
Fix schema diagnostics for directory include tags

### DIFF
--- a/src/language-service/src/haLanguageService.ts
+++ b/src/language-service/src/haLanguageService.ts
@@ -37,6 +37,13 @@ import { IConfigurationService } from "./configuration";
 export class HomeAssistantLanguageService {
   private templateCache = new Map<string, { value: string; timestamp: number }>();
   private readonly CACHE_DURATION = 30000; // 30 seconds
+  private readonly validIncludeTags = new Set(
+    Object.values(Includetype)
+      .filter((includeType): includeType is string =>
+        typeof includeType === "string",
+      )
+      .map((includeType) => `!${includeType}`),
+  );
 
   constructor(
     private yamlLanguageService: LanguageService,
@@ -256,24 +263,16 @@ export class HomeAssistantLanguageService {
         }
       }
 
-      // Fetch the text before the error, this might be "!include"
-      const includeStartChar = Math.max(0, startChar - 9);
-      const includeEndChar = Math.max(0, startChar - 1);
-      
-      if (includeStartChar < includeEndChar) {
-        const possibleInclude = document.getText(
-          Range.create(
-            startLine,
-            includeStartChar,
-            endLine,
-            includeEndChar,
-          ),
-        );
+      // yaml-language-server validates the scalar after a custom tag without
+      // the tag itself. Skip those schema errors for every supported include
+      // tag, as the included content is validated in its own file.
+      const textBeforeDiagnostic = document
+        .getText(Range.create(startLine, 0, startLine, startChar))
+        .trimEnd();
+      const possibleInclude = textBeforeDiagnostic.match(/!\w+$/)?.[0];
 
-        // Skip errors about include, everything can be included
-        if (possibleInclude === "!include") {
-          continue;
-        }
+      if (possibleInclude && this.validIncludeTags.has(possibleInclude)) {
+        continue;
       }
 
       diagnosticItem.severity = 1; // Convert all warnings to errors

--- a/src/test/suite/include-diagnostics-issue-3959.test.ts
+++ b/src/test/suite/include-diagnostics-issue-3959.test.ts
@@ -1,0 +1,52 @@
+import * as assert from "assert";
+import * as path from "path";
+import * as vscode from "vscode";
+
+suite("Include Diagnostics Issue #3959", () => {
+  suiteSetup(async () => {
+    await vscode.extensions
+      .getExtension("keesschollaart.vscode-home-assistant")
+      ?.activate();
+  });
+
+  test("Directory includes should not produce schema diagnostics", async () => {
+    const workspacePath =
+      vscode.workspace.workspaceFolders?.[0].uri.fsPath || "";
+    const configPath = path.join(workspacePath, "configuration.yaml");
+    const document = await vscode.workspace.openTextDocument(configPath);
+
+    await vscode.window.showTextDocument(document);
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    const diagnostics = vscode.languages.getDiagnostics(document.uri);
+    for (const diagnostic of diagnostics) {
+      console.log(
+        `Line ${diagnostic.range.start.line + 1}: ${diagnostic.message} ` +
+          `(${diagnostic.source}, code: ${diagnostic.code})`,
+      );
+    }
+    const lines = document.getText().split(/\r?\n/);
+    const includeLines = lines
+      .map((line, index) => ({ line, index }))
+      .filter(({ line }) => line.includes("!include_dir_"));
+
+    assert.ok(includeLines.length > 0, "Test fixture contains directory includes");
+
+    for (const includeLine of includeLines) {
+      const schemaDiagnostics = diagnostics.filter(
+        (diagnostic) =>
+          diagnostic.range.start.line === includeLine.index &&
+          (diagnostic.source?.startsWith("yaml-schema") ||
+            diagnostic.code === "patternWarning"),
+      );
+
+      assert.strictEqual(
+        schemaDiagnostics.length,
+        0,
+        `Directory include should not produce schema diagnostics: ${includeLine.line}`,
+      );
+    }
+
+    await vscode.commands.executeCommand("workbench.action.closeActiveEditor");
+  });
+});

--- a/test-workspace/configuration.yaml
+++ b/test-workspace/configuration.yaml
@@ -6,6 +6,7 @@ homeassistant:
   elevation: 0
   unit_system: metric
   time_zone: UTC
+  packages: !include_dir_named packages
 
 # Include our test files
 include:
@@ -22,3 +23,4 @@ sensor:
     name: Demo Sensor
 
 automation: !include test-goto-definition.yaml
+script: !include_dir_merge_named scripts

--- a/test-workspace/packages/test_package.yaml
+++ b/test-workspace/packages/test_package.yaml
@@ -1,0 +1,3 @@
+input_boolean:
+  include_diagnostics_test:
+    name: Include diagnostics test

--- a/test-workspace/scripts/test_script.yaml
+++ b/test-workspace/scripts/test_script.yaml
@@ -1,0 +1,3 @@
+include_diagnostics_test:
+  alias: Include diagnostics test
+  sequence: []


### PR DESCRIPTION
## Summary

- recognize every supported Home Assistant `!include*` tag when filtering schema diagnostics
- derive the allowed tags from the existing `Includetype` enum instead of maintaining a separate hard-coded list
- add regression coverage for `!include_dir_named` and `!include_dir_merge_named`

## Why

`yaml-language-server` validates the scalar following a custom tag without including the tag itself. The existing diagnostic filter handles plain `!include`, but not the directory variants. As a result, valid configurations such as:

```yaml
homeassistant:
  packages: !include_dir_named packages
```

produce a false `patternWarning`.

The updated filter only suppresses diagnostics preceded by one of the include tags already supported by the extension. Unknown custom tags are not suppressed.

## Verification

- confirmed the regression test fails on the original implementation with two `patternWarning` diagnostics
- confirmed the same test passes with this change
- `npm run compile`
- `npm run lint`
- full VS Code extension test suite: 78 passing

Fixes #3959
